### PR TITLE
hidden in UI `batch_size` parameter for Nextcloud integration

### DIFF
--- a/flows/colorful_xl.json
+++ b/flows/colorful_xl.json
@@ -56,7 +56,10 @@
         "282",
         2
       ],
-      "batch_size": 1
+      "batch_size": [
+        "317",
+        0
+      ]
     },
     "class_type": "EmptyLatentImage",
     "_meta": {
@@ -173,6 +176,7 @@
       "advanced": true,
       "order": 1,
       "custom_id": "fast_run",
+      "hidden": false,
       "input_off_state": [
         "275",
         0
@@ -197,7 +201,8 @@
       "max": 4.5,
       "step": 0.1,
       "order": 10,
-      "custom_id": "vibrancy"
+      "custom_id": "vibrancy",
+      "hidden": false
     },
     "class_type": "VixUiRangeFloat",
     "_meta": {
@@ -211,7 +216,8 @@
       "optional": false,
       "advanced": false,
       "order": 1,
-      "custom_id": "prompt"
+      "custom_id": "prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -260,8 +266,9 @@
       "min": 30,
       "max": 60,
       "step": 1,
-      "order": 99,
-      "custom_id": "steps_count"
+      "order": 98,
+      "custom_id": "steps_count",
+      "hidden": false
     },
     "class_type": "VixUiRangeInt",
     "_meta": {
@@ -321,6 +328,24 @@
     "class_type": "KSamplerAdvanced",
     "_meta": {
       "title": "KSampler (Advanced)"
+    }
+  },
+  "317": {
+    "inputs": {
+      "value": 1,
+      "display_name": "Batch size",
+      "optional": true,
+      "advanced": true,
+      "min": 1,
+      "max": 10,
+      "step": 1,
+      "order": 99,
+      "custom_id": "batch_size",
+      "hidden": true
+    },
+    "class_type": "VixUiRangeInt",
+    "_meta": {
+      "title": "VixUI-RangeInt"
     }
   }
 }

--- a/flows/flux1_dev.json
+++ b/flows/flux1_dev.json
@@ -177,7 +177,10 @@
         "30",
         2
       ],
-      "batch_size": 1
+      "batch_size": [
+        "37",
+        0
+      ]
     },
     "class_type": "EmptySD3LatentImage",
     "_meta": {
@@ -200,7 +203,8 @@
       "optional": false,
       "advanced": false,
       "order": 1,
-      "custom_id": "prompt"
+      "custom_id": "prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -236,8 +240,9 @@
       "min": 20,
       "max": 50,
       "step": 1,
-      "order": 99,
-      "custom_id": "steps_count"
+      "order": 98,
+      "custom_id": "steps_count",
+      "hidden": false
     },
     "class_type": "VixUiRangeInt",
     "_meta": {
@@ -276,11 +281,30 @@
       "max": 1,
       "step": 0.1,
       "order": 92,
-      "custom_id": "realism_lora_strength"
+      "custom_id": "realism_lora_strength",
+      "hidden": false
     },
     "class_type": "VixUiRangeFloat",
     "_meta": {
       "title": "VixUI-RangeFloat"
+    }
+  },
+  "37": {
+    "inputs": {
+      "value": 1,
+      "display_name": "Batch size",
+      "optional": true,
+      "advanced": true,
+      "min": 1,
+      "max": 10,
+      "step": 1,
+      "order": 99,
+      "custom_id": "batch_size",
+      "hidden": true
+    },
+    "class_type": "VixUiRangeInt",
+    "_meta": {
+      "title": "VixUI-RangeInt"
     }
   }
 }

--- a/flows/flux1_dev_8bit.json
+++ b/flows/flux1_dev_8bit.json
@@ -177,7 +177,10 @@
         "30",
         2
       ],
-      "batch_size": 1
+      "batch_size": [
+        "37",
+        0
+      ]
     },
     "class_type": "EmptySD3LatentImage",
     "_meta": {
@@ -200,7 +203,8 @@
       "optional": false,
       "advanced": false,
       "order": 1,
-      "custom_id": "prompt"
+      "custom_id": "prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -236,8 +240,9 @@
       "min": 20,
       "max": 50,
       "step": 1,
-      "order": 99,
-      "custom_id": "steps_count"
+      "order": 98,
+      "custom_id": "steps_count",
+      "hidden": false
     },
     "class_type": "VixUiRangeInt",
     "_meta": {
@@ -276,11 +281,30 @@
       "max": 1,
       "step": 0.1,
       "order": 92,
-      "custom_id": "realism_lora_strength"
+      "custom_id": "realism_lora_strength",
+      "hidden": false
     },
     "class_type": "VixUiRangeFloat",
     "_meta": {
       "title": "VixUI-RangeFloat"
+    }
+  },
+  "37": {
+    "inputs": {
+      "value": 1,
+      "display_name": "Batch size",
+      "optional": true,
+      "advanced": true,
+      "min": 1,
+      "max": 10,
+      "step": 1,
+      "order": 99,
+      "custom_id": "batch_size",
+      "hidden": true
+    },
+    "class_type": "VixUiRangeInt",
+    "_meta": {
+      "title": "VixUI-RangeInt"
     }
   }
 }

--- a/flows/flux1_schnell.json
+++ b/flows/flux1_schnell.json
@@ -9,7 +9,10 @@
         "27",
         2
       ],
-      "batch_size": 1
+      "batch_size": [
+        "31",
+        0
+      ]
     },
     "class_type": "EmptyLatentImage",
     "_meta": {
@@ -175,7 +178,8 @@
       "optional": false,
       "advanced": false,
       "order": 1,
-      "custom_id": "prompt"
+      "custom_id": "prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -243,11 +247,30 @@
       "max": 1,
       "step": 0.1,
       "order": 92,
-      "custom_id": "realism_lora_strength"
+      "custom_id": "realism_lora_strength",
+      "hidden": false
     },
     "class_type": "VixUiRangeFloat",
     "_meta": {
       "title": "VixUI-RangeFloat"
+    }
+  },
+  "31": {
+    "inputs": {
+      "value": 1,
+      "display_name": "Batch size",
+      "optional": true,
+      "advanced": true,
+      "min": 1,
+      "max": 10,
+      "step": 1,
+      "order": 99,
+      "custom_id": "batch_size",
+      "hidden": true
+    },
+    "class_type": "VixUiRangeInt",
+    "_meta": {
+      "title": "VixUI-RangeInt"
     }
   }
 }

--- a/flows/flux1_schnell_8bit.json
+++ b/flows/flux1_schnell_8bit.json
@@ -9,7 +9,10 @@
         "27",
         2
       ],
-      "batch_size": 1
+      "batch_size": [
+        "32",
+        0
+      ]
     },
     "class_type": "EmptyLatentImage",
     "_meta": {
@@ -175,7 +178,8 @@
       "optional": false,
       "advanced": false,
       "order": 1,
-      "custom_id": "prompt"
+      "custom_id": "prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -243,11 +247,30 @@
       "max": 1,
       "step": 0.1,
       "order": 92,
-      "custom_id": "realism_lora_strength"
+      "custom_id": "realism_lora_strength",
+      "hidden": false
     },
     "class_type": "VixUiRangeFloat",
     "_meta": {
       "title": "VixUI-RangeFloat"
+    }
+  },
+  "32": {
+    "inputs": {
+      "value": 1,
+      "display_name": "Batch size",
+      "optional": true,
+      "advanced": true,
+      "min": 1,
+      "max": 10,
+      "step": 1,
+      "order": 99,
+      "custom_id": "batch_size",
+      "hidden": true
+    },
+    "class_type": "VixUiRangeInt",
+    "_meta": {
+      "title": "VixUI-RangeInt"
     }
   }
 }

--- a/flows/hunyuan_dit.json
+++ b/flows/hunyuan_dit.json
@@ -28,7 +28,10 @@
     "inputs": {
       "width": 1024,
       "height": 1024,
-      "batch_size": 1
+      "batch_size": [
+        "309",
+        0
+      ]
     },
     "class_type": "EmptyLatentImage",
     "_meta": {
@@ -75,7 +78,8 @@
       "optional": false,
       "advanced": false,
       "order": 1,
-      "custom_id": "prompt"
+      "custom_id": "prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -89,7 +93,8 @@
       "optional": true,
       "advanced": true,
       "order": 15,
-      "custom_id": "negative_prompt"
+      "custom_id": "negative_prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -174,7 +179,8 @@
       "max": 60,
       "step": 1,
       "order": 91,
-      "custom_id": "steps_count"
+      "custom_id": "steps_count",
+      "hidden": false
     },
     "class_type": "VixUiRangeInt",
     "_meta": {
@@ -191,11 +197,30 @@
       "max": 15,
       "step": 0.1,
       "order": 90,
-      "custom_id": "vibrancy"
+      "custom_id": "vibrancy",
+      "hidden": false
     },
     "class_type": "VixUiRangeFloat",
     "_meta": {
       "title": "VixUI-RangeFloat"
+    }
+  },
+  "309": {
+    "inputs": {
+      "value": 1,
+      "display_name": "Batch size",
+      "optional": true,
+      "advanced": true,
+      "min": 1,
+      "max": 10,
+      "step": 1,
+      "order": 99,
+      "custom_id": "batch_size",
+      "hidden": true
+    },
+    "class_type": "VixUiRangeInt",
+    "_meta": {
+      "title": "VixUI-RangeInt"
     }
   }
 }

--- a/flows/juggernaut_lite.json
+++ b/flows/juggernaut_lite.json
@@ -138,7 +138,10 @@
         "270",
         2
       ],
-      "batch_size": 1
+      "batch_size": [
+        "271",
+        0
+      ]
     },
     "class_type": "EmptyLatentImage",
     "_meta": {
@@ -288,7 +291,10 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/Juggernaut_Lite.html",
       "license": "",
       "tags": "[\"general\", \"simple\"]",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "requires": "[]",
+      "is_seed_supported": true,
+      "is_count_supported": true
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -302,7 +308,8 @@
       "optional": false,
       "advanced": false,
       "order": 1,
-      "custom_id": "prompt"
+      "custom_id": "prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -316,7 +323,8 @@
       "optional": true,
       "advanced": true,
       "order": 15,
-      "custom_id": "negative_prompt"
+      "custom_id": "negative_prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -330,6 +338,24 @@
     "class_type": "SDXLAspectRatioSelector",
     "_meta": {
       "title": "input;Aspect Ratio;optional;advanced;custom_id=aspect_ratio"
+    }
+  },
+  "271": {
+    "inputs": {
+      "value": 1,
+      "display_name": "Batch size",
+      "optional": true,
+      "advanced": true,
+      "min": 1,
+      "max": 10,
+      "step": 1,
+      "order": 99,
+      "custom_id": "batch_size",
+      "hidden": true
+    },
+    "class_type": "VixUiRangeInt",
+    "_meta": {
+      "title": "VixUI-RangeInt"
     }
   }
 }

--- a/flows/mobius_xl.json
+++ b/flows/mobius_xl.json
@@ -61,7 +61,10 @@
     "inputs": {
       "width": 1024,
       "height": 1024,
-      "batch_size": 1
+      "batch_size": [
+        "298",
+        0
+      ]
     },
     "class_type": "EmptyLatentImage",
     "_meta": {
@@ -187,7 +190,10 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/Mobius_XL.html",
       "license": "",
       "tags": "[\"general\", \"simple\"]",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "requires": "[]",
+      "is_seed_supported": true,
+      "is_count_supported": true
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -201,7 +207,8 @@
       "optional": false,
       "advanced": false,
       "order": 1,
-      "custom_id": "prompt"
+      "custom_id": "prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -215,7 +222,8 @@
       "optional": true,
       "advanced": true,
       "order": 15,
-      "custom_id": "negative_prompt"
+      "custom_id": "negative_prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -262,6 +270,7 @@
       "advanced": true,
       "order": 98,
       "custom_id": "fast_run",
+      "hidden": false,
       "input_off_state": [
         "116",
         0
@@ -285,12 +294,31 @@
       "min": 3.5,
       "max": 7,
       "step": 0.1,
-      "order": 99,
-      "custom_id": "prompt_strength"
+      "order": 98,
+      "custom_id": "prompt_strength",
+      "hidden": false
     },
     "class_type": "VixUiRangeFloat",
     "_meta": {
       "title": "VixUI-RangeFloat"
+    }
+  },
+  "298": {
+    "inputs": {
+      "value": 1,
+      "display_name": "Batch size",
+      "optional": true,
+      "advanced": true,
+      "min": 1,
+      "max": 10,
+      "step": 1,
+      "order": 99,
+      "custom_id": "batch_size",
+      "hidden": true
+    },
+    "class_type": "VixUiRangeInt",
+    "_meta": {
+      "title": "VixUI-RangeInt"
     }
   }
 }

--- a/flows/playground_2_5_aesthetic.json
+++ b/flows/playground_2_5_aesthetic.json
@@ -127,7 +127,10 @@
         "281",
         2
       ],
-      "batch_size": 1
+      "batch_size": [
+        "283",
+        0
+      ]
     },
     "class_type": "EmptyLatentImage",
     "_meta": {
@@ -203,7 +206,9 @@
       "license": "",
       "tags": "[\"general\", \"simple\"]",
       "version": "1.1.0",
-      "requires": "[]"
+      "requires": "[]",
+      "is_seed_supported": true,
+      "is_count_supported": true
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -217,7 +222,8 @@
       "optional": false,
       "advanced": false,
       "order": 1,
-      "custom_id": "prompt"
+      "custom_id": "prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -231,7 +237,8 @@
       "optional": true,
       "advanced": true,
       "order": 15,
-      "custom_id": "negative_prompt"
+      "custom_id": "negative_prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -247,8 +254,9 @@
       "min": 3,
       "max": 5,
       "step": 0.1,
-      "order": 99,
-      "custom_id": "prompt_strength"
+      "order": 98,
+      "custom_id": "prompt_strength",
+      "hidden": false
     },
     "class_type": "VixUiRangeFloat",
     "_meta": {
@@ -263,6 +271,7 @@
       "advanced": true,
       "order": 98,
       "custom_id": "fast_run",
+      "hidden": false,
       "input_off_state": [
         "240",
         0
@@ -300,6 +309,24 @@
     "class_type": "VAEDecode",
     "_meta": {
       "title": "VAE Decode"
+    }
+  },
+  "283": {
+    "inputs": {
+      "value": 1,
+      "display_name": "Batch size",
+      "optional": true,
+      "advanced": true,
+      "min": 1,
+      "max": 10,
+      "step": 1,
+      "order": 99,
+      "custom_id": "batch_size",
+      "hidden": true
+    },
+    "class_type": "VixUiRangeInt",
+    "_meta": {
+      "title": "VixUI-RangeInt"
     }
   }
 }

--- a/flows/playground_2_5_prometheus.json
+++ b/flows/playground_2_5_prometheus.json
@@ -115,7 +115,10 @@
         "281",
         2
       ],
-      "batch_size": 1
+      "batch_size": [
+        "286",
+        0
+      ]
     },
     "class_type": "EmptyLatentImage",
     "_meta": {
@@ -133,7 +136,9 @@
       "license": "",
       "tags": "[\"general\", \"simple\"]",
       "version": "1.0.0",
-      "requires": "[]"
+      "requires": "[]",
+      "is_seed_supported": true,
+      "is_count_supported": true
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -147,7 +152,8 @@
       "optional": false,
       "advanced": false,
       "order": 1,
-      "custom_id": "prompt"
+      "custom_id": "prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -161,7 +167,8 @@
       "optional": true,
       "advanced": true,
       "order": 15,
-      "custom_id": "negative_prompt"
+      "custom_id": "negative_prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -177,8 +184,9 @@
       "min": 6,
       "max": 8,
       "step": 0.1,
-      "order": 99,
-      "custom_id": "prompt_strength"
+      "order": 98,
+      "custom_id": "prompt_strength",
+      "hidden": false
     },
     "class_type": "VixUiRangeFloat",
     "_meta": {
@@ -216,8 +224,27 @@
       "min": 25,
       "max": 50,
       "step": 1,
+      "order": 97,
+      "custom_id": "steps_count",
+      "hidden": false
+    },
+    "class_type": "VixUiRangeInt",
+    "_meta": {
+      "title": "VixUI-RangeInt"
+    }
+  },
+  "286": {
+    "inputs": {
+      "value": 1,
+      "display_name": "Batch size",
+      "optional": true,
+      "advanced": true,
+      "min": 1,
+      "max": 10,
+      "step": 1,
       "order": 99,
-      "custom_id": "steps_count"
+      "custom_id": "batch_size",
+      "hidden": true
     },
     "class_type": "VixUiRangeInt",
     "_meta": {

--- a/flows/sdxl_lighting.json
+++ b/flows/sdxl_lighting.json
@@ -42,7 +42,10 @@
     "inputs": {
       "width": 1024,
       "height": 1024,
-      "batch_size": 1
+      "batch_size": [
+        "25",
+        0
+      ]
     },
     "class_type": "EmptyLatentImage",
     "_meta": {
@@ -204,7 +207,8 @@
       "optional": false,
       "advanced": false,
       "order": 1,
-      "custom_id": "prompt"
+      "custom_id": "prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -218,7 +222,8 @@
       "optional": true,
       "advanced": true,
       "order": 25,
-      "custom_id": "negative_prompt"
+      "custom_id": "negative_prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -235,7 +240,10 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/SDXL_Lighting.html",
       "license": "",
       "tags": "[\"general\", \"lighting\", \"simple\"]",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "requires": "[]",
+      "is_seed_supported": true,
+      "is_count_supported": true
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -251,6 +259,7 @@
       "advanced": true,
       "order": 20,
       "custom_id": "steps_number",
+      "hidden": false,
       "input_first": [
         "12",
         0
@@ -263,6 +272,24 @@
     "class_type": "VixUiListLogic",
     "_meta": {
       "title": "VixUI-ListLogic"
+    }
+  },
+  "25": {
+    "inputs": {
+      "value": 1,
+      "display_name": "Batch size",
+      "optional": true,
+      "advanced": true,
+      "min": 1,
+      "max": 10,
+      "step": 1,
+      "order": 99,
+      "custom_id": "batch_size",
+      "hidden": true
+    },
+    "class_type": "VixUiRangeInt",
+    "_meta": {
+      "title": "VixUI-RangeInt"
     }
   }
 }

--- a/flows/stable_cascade.json
+++ b/flows/stable_cascade.json
@@ -158,7 +158,10 @@
       "width": 1024,
       "height": 576,
       "compression": 32,
-      "batch_size": 1
+      "batch_size": [
+        "104",
+        0
+      ]
     },
     "class_type": "StableCascade_EmptyLatentImage",
     "_meta": {
@@ -461,6 +464,7 @@
       "advanced": true,
       "order": 20,
       "custom_id": "pass_count",
+      "hidden": false,
       "input_first": [
         "22",
         0
@@ -486,7 +490,8 @@
       "optional": false,
       "advanced": false,
       "order": 1,
-      "custom_id": "prompt"
+      "custom_id": "prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -500,7 +505,8 @@
       "optional": true,
       "advanced": true,
       "order": 25,
-      "custom_id": "negative_prompt"
+      "custom_id": "negative_prompt",
+      "hidden": false
     },
     "class_type": "VixUiPrompt",
     "_meta": {
@@ -517,11 +523,32 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/Stable_Cascade.html",
       "license": "",
       "tags": "[\"general\", \"simple\"]",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "requires": "[]",
+      "is_seed_supported": true,
+      "is_count_supported": true
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
       "title": "VixUI-WorkflowMetadata"
+    }
+  },
+  "104": {
+    "inputs": {
+      "value": 1,
+      "display_name": "Batch size",
+      "optional": true,
+      "advanced": true,
+      "min": 1,
+      "max": 10,
+      "step": 1,
+      "order": 99,
+      "custom_id": "batch_size",
+      "hidden": true
+    },
+    "class_type": "VixUiRangeInt",
+    "_meta": {
+      "title": "VixUI-RangeInt"
     }
   }
 }


### PR DESCRIPTION
To be an AI Image Provider in Nextcloud, we need to support the `count` parameter

A `count `in Visionatrix is ​​not the same as a `count` in Nextcloud, Visionatrix creates multiple tasks (one per `count` value) - to parallelize work between workers.

In order not to suffer too much with support and integration, we will add the "batch_size" parameter and this will be what "count" is in Nextcloud API