### PR TITLE
fix: FP8 Flux-1 models files was renamed in the remote repo

### DIFF
--- a/models_catalog.json
+++ b/models_catalog.json
@@ -690,7 +690,7 @@
       }
     ],
     "save_path": "unet/flux1-schnell-fp8.safetensors",
-    "url": "https://huggingface.co/Kijai/flux-fp8/resolve/main/flux1-schnell-fp8.safetensors",
+    "url": "https://huggingface.co/Kijai/flux-fp8/resolve/main/flux1-schnell-fp8-e4m3fn.safetensors",
     "homepage": "https://huggingface.co/Kijai/flux-fp8",
     "hash": "bbdfba27fed8ff3be237523fb37b83821a6c4bbaa1db43ef9288767d0e4042fb"
   },
@@ -714,7 +714,7 @@
       }
     ],
     "save_path": "unet/flux1-dev-fp8.safetensors",
-    "url": "https://huggingface.co/Kijai/flux-fp8/resolve/main/flux1-dev-fp8.safetensors",
+    "url": "https://huggingface.co/Kijai/flux-fp8/resolve/main/flux1-dev-fp8-e4m3fn.safetensors",
     "homepage": "https://huggingface.co/Kijai/flux-fp8",
     "hash": "1be961341be8f5307ef26c787199f80bf4e0de3c1c0b4617095aa6ee5550dfce"
   },


### PR DESCRIPTION
Failed action: https://github.com/Visionatrix/VixFlowsDocs/actions/runs/10756045791/job/29828478309

Topic on the HF: https://huggingface.co/Kijai/flux-fp8/discussions/27

Hashes remain the same, so it is really only the renaming. We do not rename it, just change the urls