### PR TITLE
removed mention of `flows_dir` as both argument and env variable

### DIFF
--- a/docs/AdminManual/command_line_options.md
+++ b/docs/AdminManual/command_line_options.md
@@ -16,10 +16,9 @@ Below are the command-line options related to Visionatrix and ComfyUI.
 
 ## Common Options for Multiple Commands
 
-The following options can be specified for the `install`, `update`, `install-flow`, `orphan-models`, and `openapi` commands:
+The following option can be specified for the `install`, `update`, `install-flow`, `orphan-models`, and `openapi` commands:
 
 - `--backend_dir=BACKEND_DIR`: Directory for the folder with ComfyUI. Default: `vix_backend`
-- `--flows_dir=FLOWS_DIR`: Directory for the flows. Default: `vix_flows`
 
 ## The `run` Command
 
@@ -63,7 +62,6 @@ python3 -m visionatrix [--verbose=LEVEL] run [options]
         **Note:** The `--verbose` option should be specified **before** any command (e.g., `run`, `install`, `update`).
 
 - `--backend_dir=BACKEND_DIR`: Directory for the folder with ComfyUI. Default: `vix_backend`
-- `--flows_dir=FLOWS_DIR`: Directory for the flows. Default: `vix_flows`
 
 #### ComfyUI Options
 
@@ -192,7 +190,6 @@ python3 -m visionatrix [--verbose=LEVEL] install [options]
 ### Options
 
 - `--backend_dir=BACKEND_DIR`: Directory for the folder with ComfyUI. Default: `vix_backend`
-- `--flows_dir=FLOWS_DIR`: Directory for the flows. Default: `vix_flows`
 
 ### Example
 
@@ -215,7 +212,6 @@ python3 -m visionatrix [--verbose=LEVEL] update [options]
 ### Options
 
 - `--backend_dir=BACKEND_DIR`: Directory for the folder with ComfyUI. Default: `vix_backend`
-- `--flows_dir=FLOWS_DIR`: Directory for the flows. Default: `vix_flows`
 
 ### Example
 
@@ -246,7 +242,6 @@ You must specify one of the following options:
 Additional options:
 
 - `--backend_dir=BACKEND_DIR`: Directory for the folder with ComfyUI. Default: `vix_backend`
-- `--flows_dir=FLOWS_DIR`: Directory for the flows. Default: `vix_flows`
 
 ### Examples
 
@@ -313,7 +308,6 @@ python3 -m visionatrix [--verbose=LEVEL] orphan-models [options]
 - `--dry-run`: Perform cleaning without actually removing models.
 - `--include-useful-models`: Include orphaned models that can be used in future flows for removal.
 - `--backend_dir=BACKEND_DIR`: Directory for the folder with ComfyUI. Default: `vix_backend`
-- `--flows_dir=FLOWS_DIR`: Directory for the flows. Default: `vix_flows`
 
 ### Example
 
@@ -342,7 +336,6 @@ python3 -m visionatrix [--verbose=LEVEL] openapi [options]
 - `--skip-not-installed`: Skip flows that are not installed. Default: `True`.
 - `--exclude-base`: Exclude base application endpoints from OpenAPI specs.
 - `--backend_dir=BACKEND_DIR`: Directory for the folder with ComfyUI. Default: `vix_backend`
-- `--flows_dir=FLOWS_DIR`: Directory for the flows. Default: `vix_flows`
 
 ### Examples
 

--- a/docs/AdminManual/environment_variables.md
+++ b/docs/AdminManual/environment_variables.md
@@ -29,15 +29,6 @@ VARIABLE_NAME=value
 
         The command-line argument `--backend_dir=BACKEND_DIR` takes precedence over the environment variable.
 
-### FLOWS_DIR
-
-- **Description**: Directory for storing flows. The path can be absolute or relative.
-- **Default**: `./vix_flows`
-
-    !!! note
-
-        The command-line argument `--flows_dir=FLOWS_DIR` takes precedence over the environment variable.
-
 ### TASKS_FILES_DIR
 
 - **Description**: Directory for input/output files. The path can be absolute or relative.
@@ -282,7 +273,7 @@ set WORKER_AUTH=worker_user:worker_password
 ### Starting Visionatrix with Command-Line Arguments
 
 ```bash
-python3 -m visionatrix run --backend_dir=/path/to/backend --flows_dir=/path/to/flows --tasks_files_dir=/path/to/tasks_files --ui
+python3 -m visionatrix run --backend_dir=/path/to/backend --tasks_files_dir=/path/to/tasks_files --ui
 ```
 
 In this example, the directories are specified via command-line arguments, which will override any environment variables or settings in the `.env` file.


### PR DESCRIPTION
Starting from upcoming Visionatrix `1.8` version we store this information in the database,  PR reference: 
[Remove FLOWS_DIR option#242](https://github.com/Visionatrix/Visionatrix/pull/242)