### PR TITLE
BiRefNet_ll node: updated flows that were depending on rmbg

### DIFF
--- a/flows/all_your_life.json
+++ b/flows/all_your_life.json
@@ -162,6 +162,7 @@
       "pix_fmt": "yuv420p",
       "crf": 19,
       "save_metadata": true,
+      "trim_to_audio": false,
       "pingpong": false,
       "save_output": true,
       "images": [
@@ -383,18 +384,6 @@
       "title": "Auto Crop Faces"
     }
   },
-  "405": {
-    "inputs": {
-      "image": [
-        "491",
-        0
-      ]
-    },
-    "class_type": "SplitImageWithAlpha",
-    "_meta": {
-      "title": "Split Image with Alpha"
-    }
-  },
   "406": {
     "inputs": {
       "weight": 1,
@@ -458,7 +447,7 @@
   },
   "417": {
     "inputs": {
-      "text": "\"0\" :\"Three months old,litte girl，baby:2，kawaii,very short hair\",\n\"1\" :\"5-year-old,cute kid,girl\",\n\"2\" :\"16-year-old,young girl,long hair\",\n\"3\" :\"26-year-old,woman,long hair\",\n\"4\" :\"44-year-old,old woman\",\n\"5\" :\"64-year-old,old woman,gray hair\",\n\"6\" :\"84-year-old,old woman,wrinkles,white hair\",\n\"7\" :\"104-year-old,very old woman,wrinkles:2,white hair\","
+      "text": "\"0\" :\"6-year,litte girl，kawaii:2,short hair\",\n\"1\" :\"10-year-old,cute kid,girl\",\n\"2\" :\"16-year-old,young girl,long hair\",\n\"3\" :\"26-year-old,woman,long hair\",\n\"4\" :\"44-year-old,old woman\",\n\"5\" :\"64-year-old,old woman,gray hair\",\n\"6\" :\"84-year-old,old woman,wrinkles,white hair\",\n\"7\" :\"104-year-old,very old woman,wrinkles:2,white hair\","
     },
     "class_type": "Text Multiline (Code Compatible)",
     "_meta": {
@@ -467,7 +456,7 @@
   },
   "418": {
     "inputs": {
-      "text": "\"0\" :\"Three months old,litte boy，baby:2,kawaii,very short hair\",\n\"1\" :\"5-year-old,cute boy,short hair\",\n\"2\" :\"16-year-old,handsome man\",\n\"3\" :\"26-year-old,handsome man\",\n\"4\" :\"44-year-old,old man\",\n\"5\" :\"64-year-old,old man,gray hair\",\n\"6\" :\"84-year-old,old man,wrinkles,white hair\",\n\"7\" :\"104-year-old,very old man,wrinkles:2,bald,white hair\","
+      "text": "\"0\" :\"6-year,litte boy,kawaii:2,very short hair\",\n\"1\" :\"10-year-old,cute boy,short hair\",\n\"2\" :\"16-year-old,handsome man\",\n\"3\" :\"26-year-old,handsome man\",\n\"4\" :\"44-year-old,old man\",\n\"5\" :\"64-year-old,old man,gray hair\",\n\"6\" :\"84-year-old,old man,wrinkles,white hair\",\n\"7\" :\"104-year-old,very old man,wrinkles:2,bald,white hair\","
     },
     "class_type": "Text Multiline",
     "_meta": {
@@ -607,7 +596,7 @@
       "height": 1024,
       "crop": "center",
       "image": [
-        "405",
+        "400",
         0
       ]
     },
@@ -660,7 +649,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/AllYourLife",
       "license": "",
       "tags": "[\"general\", \"portrait\", \"sketch\", \"video\"]",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "requires": "[\"Ollama:llava:7b-v1.6-vicuna-q8_0\"]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -771,26 +760,6 @@
     "class_type": "Text Find and Replace",
     "_meta": {
       "title": "Text Find and Replace(if LLM is dumb)"
-    }
-  },
-  "491": {
-    "inputs": {
-      "detail_method": "GuidedFilter",
-      "detail_erode": 6,
-      "detail_dilate": 6,
-      "black_point": 0.01,
-      "white_point": 0.99,
-      "process_detail": false,
-      "device": "cpu",
-      "max_megapixels": 2,
-      "image": [
-        "400",
-        0
-      ]
-    },
-    "class_type": "LayerMask: RmBgUltra V2",
-    "_meta": {
-      "title": "LayerMask: RmBgUltra V2"
     }
   }
 }

--- a/flows/ghibli_portrait.json
+++ b/flows/ghibli_portrait.json
@@ -55,7 +55,7 @@
         0
       ],
       "image": [
-        "397",
+        "389",
         0
       ],
       "model": [
@@ -196,7 +196,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/GhibliPortrait/",
       "license": "",
       "tags": "[\"anime\", \"portrait\"]",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -300,26 +300,6 @@
     "class_type": "VixUiList",
     "_meta": {
       "title": "VixUI-List"
-    }
-  },
-  "397": {
-    "inputs": {
-      "detail_method": "GuidedFilter",
-      "detail_erode": 6,
-      "detail_dilate": 6,
-      "black_point": 0.01,
-      "white_point": 0.99,
-      "process_detail": false,
-      "device": "cpu",
-      "max_megapixels": 2,
-      "image": [
-        "389",
-        0
-      ]
-    },
-    "class_type": "LayerMask: RmBgUltra V2",
-    "_meta": {
-      "title": "LayerMask: RmBgUltra V2"
     }
   }
 }

--- a/flows/photo_stickers.json
+++ b/flows/photo_stickers.json
@@ -3,7 +3,7 @@
     "inputs": {
       "filename_prefix": "240_10",
       "images": [
-        "377",
+        "383",
         0
       ]
     },
@@ -136,7 +136,7 @@
     "inputs": {
       "filename_prefix": "240_79",
       "images": [
-        "378",
+        "381",
         0
       ]
     },
@@ -149,7 +149,7 @@
     "inputs": {
       "filename_prefix": "240_80",
       "images": [
-        "379",
+        "384",
         0
       ]
     },
@@ -162,7 +162,7 @@
     "inputs": {
       "filename_prefix": "240_82",
       "images": [
-        "380",
+        "385",
         0
       ]
     },
@@ -856,7 +856,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/PhotoStickers/",
       "license": "",
       "tags": "[\"cartoon\", \"portrait\"]",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -1091,84 +1091,79 @@
       "title": "Text Multiline (Code Compatible)"
     }
   },
-  "377": {
+  "381": {
     "inputs": {
-      "detail_method": "GuidedFilter",
-      "detail_erode": 6,
-      "detail_dilate": 6,
-      "black_point": 0.01,
-      "white_point": 0.99,
-      "process_detail": false,
-      "device": "cpu",
-      "max_megapixels": 2,
-      "image": [
-        "341",
+      "model": [
+        "382",
         0
-      ]
-    },
-    "class_type": "LayerMask: RmBgUltra V2",
-    "_meta": {
-      "title": "LayerMask: RmBgUltra V2"
-    }
-  },
-  "378": {
-    "inputs": {
-      "detail_method": "GuidedFilter",
-      "detail_erode": 6,
-      "detail_dilate": 6,
-      "black_point": 0.01,
-      "white_point": 0.99,
-      "process_detail": false,
-      "device": "cpu",
-      "max_megapixels": 2,
-      "image": [
+      ],
+      "images": [
         "343",
         0
       ]
     },
-    "class_type": "LayerMask: RmBgUltra V2",
+    "class_type": "RembgByBiRefNet",
     "_meta": {
-      "title": "LayerMask: RmBgUltra V2"
+      "title": "RembgByBiRefNet"
     }
   },
-  "379": {
+  "382": {
     "inputs": {
-      "detail_method": "GuidedFilter",
-      "detail_erode": 6,
-      "detail_dilate": 6,
-      "black_point": 0.01,
-      "white_point": 0.99,
-      "process_detail": false,
-      "device": "cpu",
-      "max_megapixels": 2,
-      "image": [
+      "model": "General.safetensors",
+      "device": "AUTO",
+      "use_weight": false
+    },
+    "class_type": "LoadRembgByBiRefNetModel",
+    "_meta": {
+      "title": "LoadRembgByBiRefNetModel"
+    }
+  },
+  "383": {
+    "inputs": {
+      "model": [
+        "382",
+        0
+      ],
+      "images": [
+        "341",
+        0
+      ]
+    },
+    "class_type": "RembgByBiRefNet",
+    "_meta": {
+      "title": "RembgByBiRefNet"
+    }
+  },
+  "384": {
+    "inputs": {
+      "model": [
+        "382",
+        0
+      ],
+      "images": [
         "344",
         0
       ]
     },
-    "class_type": "LayerMask: RmBgUltra V2",
+    "class_type": "RembgByBiRefNet",
     "_meta": {
-      "title": "LayerMask: RmBgUltra V2"
+      "title": "RembgByBiRefNet"
     }
   },
-  "380": {
+  "385": {
     "inputs": {
-      "detail_method": "GuidedFilter",
-      "detail_erode": 6,
-      "detail_dilate": 6,
-      "black_point": 0.01,
-      "white_point": 0.99,
-      "process_detail": false,
-      "device": "cpu",
-      "max_megapixels": 2,
-      "image": [
+      "model": [
+        "382",
+        0
+      ],
+      "images": [
         "346",
         0
       ]
     },
-    "class_type": "LayerMask: RmBgUltra V2",
+    "class_type": "RembgByBiRefNet",
     "_meta": {
-      "title": "LayerMask: RmBgUltra V2"
+      "title": "RembgByBiRefNet"
     }
   }
 }

--- a/flows/photo_stickers2.json
+++ b/flows/photo_stickers2.json
@@ -498,7 +498,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/PhotoStickers2/",
       "license": "",
       "tags": "[\"cartoon\", \"portrait\"]",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "requires": "[\"Ollama:llava:7b-v1.6-vicuna-q8_0\"]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -514,7 +514,7 @@
       "batch_index": 0,
       "length": 1,
       "image": [
-        "587",
+        "589",
         0
       ]
     },
@@ -528,7 +528,7 @@
       "batch_index": 1,
       "length": 1,
       "image": [
-        "587",
+        "589",
         0
       ]
     },
@@ -542,7 +542,7 @@
       "batch_index": 2,
       "length": 1,
       "image": [
-        "587",
+        "589",
         0
       ]
     },
@@ -556,7 +556,7 @@
       "batch_index": 3,
       "length": 1,
       "image": [
-        "587",
+        "589",
         0
       ]
     },
@@ -659,24 +659,31 @@
       "title": "Ask Gemini"
     }
   },
-  "587": {
+  "588": {
     "inputs": {
-      "detail_method": "GuidedFilter",
-      "detail_erode": 6,
-      "detail_dilate": 6,
-      "black_point": 0.01,
-      "white_point": 0.99,
-      "process_detail": false,
-      "device": "cpu",
-      "max_megapixels": 2,
-      "image": [
+      "model": "General.safetensors",
+      "device": "AUTO",
+      "use_weight": false
+    },
+    "class_type": "LoadRembgByBiRefNetModel",
+    "_meta": {
+      "title": "LoadRembgByBiRefNetModel"
+    }
+  },
+  "589": {
+    "inputs": {
+      "model": [
+        "588",
+        0
+      ],
+      "images": [
         "378",
         5
       ]
     },
-    "class_type": "LayerMask: RmBgUltra V2",
+    "class_type": "RembgByBiRefNet",
     "_meta": {
-      "title": "LayerMask: RmBgUltra V2"
+      "title": "RembgByBiRefNet"
     }
   }
 }

--- a/flows/photomaker_1.json
+++ b/flows/photomaker_1.json
@@ -269,7 +269,7 @@
   "97": {
     "inputs": {
       "image": [
-        "132",
+        "133",
         0
       ]
     },
@@ -288,7 +288,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/Photomaker_1/",
       "license": "",
       "tags": "[\"general\", \"portrait\", \"cartoon\"]",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -578,24 +578,22 @@
       "title": "Text Dictionary New"
     }
   },
-  "132": {
+  "133": {
     "inputs": {
-      "detail_method": "GuidedFilter",
-      "detail_erode": 6,
-      "detail_dilate": 6,
-      "black_point": 0.01,
-      "white_point": 0.99,
-      "process_detail": false,
-      "device": "cpu",
-      "max_megapixels": 2,
+      "number_of_faces": 1,
+      "scale_factor": 4.3,
+      "shift_factor": 0.45,
+      "start_index": 0,
+      "max_faces_per_image": 50,
+      "aspect_ratio": "1:1",
       "image": [
         "100",
         0
       ]
     },
-    "class_type": "LayerMask: RmBgUltra V2",
+    "class_type": "AutoCropFaces",
     "_meta": {
-      "title": "LayerMask: RmBgUltra V2"
+      "title": "Auto Crop Faces"
     }
   }
 }

--- a/flows/photomaker_2.json
+++ b/flows/photomaker_2.json
@@ -499,30 +499,6 @@
       "title": "Text Multiline"
     }
   },
-  "223": {
-    "inputs": {
-      "image": [
-        "256",
-        0
-      ]
-    },
-    "class_type": "SplitImageWithAlpha",
-    "_meta": {
-      "title": "Split Image with Alpha"
-    }
-  },
-  "224": {
-    "inputs": {
-      "image": [
-        "255",
-        0
-      ]
-    },
-    "class_type": "SplitImageWithAlpha",
-    "_meta": {
-      "title": "Split Image with Alpha"
-    }
-  },
   "225": {
     "inputs": {
       "name": "photomaker_2",
@@ -533,7 +509,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/Photomaker_2/",
       "license": "",
       "tags": "[\"general\", \"portrait\"]",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -674,18 +650,6 @@
       "title": "Auto Crop Faces"
     }
   },
-  "244": {
-    "inputs": {
-      "image": [
-        "257",
-        0
-      ]
-    },
-    "class_type": "SplitImageWithAlpha",
-    "_meta": {
-      "title": "Split Image with Alpha"
-    }
-  },
   "247": {
     "inputs": {
       "number_of_faces": 1,
@@ -704,121 +668,29 @@
       "title": "Auto Crop Faces"
     }
   },
-  "249": {
-    "inputs": {
-      "image": [
-        "258",
-        0
-      ]
-    },
-    "class_type": "SplitImageWithAlpha",
-    "_meta": {
-      "title": "Split Image with Alpha"
-    }
-  },
   "254": {
     "inputs": {
       "method": "lanczos",
       "image_1": [
-        "224",
+        "211",
         0
       ],
       "image_2": [
-        "223",
+        "209",
         0
       ],
       "image_3": [
-        "244",
+        "242",
         0
       ],
       "image_4": [
-        "249",
+        "247",
         0
       ]
     },
     "class_type": "ImageBatchMultiple+",
     "_meta": {
       "title": "🔧 Images Batch Multiple"
-    }
-  },
-  "255": {
-    "inputs": {
-      "detail_method": "GuidedFilter",
-      "detail_erode": 6,
-      "detail_dilate": 6,
-      "black_point": 0.01,
-      "white_point": 0.99,
-      "process_detail": false,
-      "device": "cpu",
-      "max_megapixels": 2,
-      "image": [
-        "211",
-        0
-      ]
-    },
-    "class_type": "LayerMask: RmBgUltra V2",
-    "_meta": {
-      "title": "LayerMask: RmBgUltra V2"
-    }
-  },
-  "256": {
-    "inputs": {
-      "detail_method": "GuidedFilter",
-      "detail_erode": 6,
-      "detail_dilate": 6,
-      "black_point": 0.01,
-      "white_point": 0.99,
-      "process_detail": false,
-      "device": "cpu",
-      "max_megapixels": 2,
-      "image": [
-        "209",
-        0
-      ]
-    },
-    "class_type": "LayerMask: RmBgUltra V2",
-    "_meta": {
-      "title": "LayerMask: RmBgUltra V2"
-    }
-  },
-  "257": {
-    "inputs": {
-      "detail_method": "GuidedFilter",
-      "detail_erode": 6,
-      "detail_dilate": 6,
-      "black_point": 0.01,
-      "white_point": 0.99,
-      "process_detail": false,
-      "device": "cpu",
-      "max_megapixels": 2,
-      "image": [
-        "209",
-        0
-      ]
-    },
-    "class_type": "LayerMask: RmBgUltra V2",
-    "_meta": {
-      "title": "LayerMask: RmBgUltra V2"
-    }
-  },
-  "258": {
-    "inputs": {
-      "detail_method": "GuidedFilter",
-      "detail_erode": 6,
-      "detail_dilate": 6,
-      "black_point": 0.01,
-      "white_point": 0.99,
-      "process_detail": false,
-      "device": "cpu",
-      "max_megapixels": 2,
-      "image": [
-        "247",
-        0
-      ]
-    },
-    "class_type": "LayerMask: RmBgUltra V2",
-    "_meta": {
-      "title": "LayerMask: RmBgUltra V2"
     }
   }
 }


### PR DESCRIPTION
Second part of #71 PR.

Removed `rmbg` where it is possible to do, as new `rmbg` flows works very bad on macOS.

Where it is not possible to remove remove background functionality(photostickers 1/2) - transfered them to new node and later we will introduce flags that shows with which workers OS they are compatible.