### PR TITLE
replace WAS-Node-Suite node usage with ComfyUI-Visionatrix node

### DIFF
--- a/flows/all_your_life.json
+++ b/flows/all_your_life.json
@@ -132,7 +132,7 @@
   "224": {
     "inputs": {
       "text": [
-        "490",
+        "503",
         0
       ],
       "max_frames": 8,
@@ -151,28 +151,6 @@
     "class_type": "BatchPromptSchedule",
     "_meta": {
       "title": "Batch Prompt Schedule 📅🅕🅝"
-    }
-  },
-  "225": {
-    "inputs": {
-      "frame_rate": 12,
-      "loop_count": 0,
-      "filename_prefix": "ComfyUI",
-      "format": "video/h264-mp4",
-      "pix_fmt": "yuv420p",
-      "crf": 19,
-      "save_metadata": true,
-      "trim_to_audio": false,
-      "pingpong": false,
-      "save_output": true,
-      "images": [
-        "361",
-        0
-      ]
-    },
-    "class_type": "VHS_VideoCombine",
-    "_meta": {
-      "title": "Video Combine 🎥🅥🅗🅢"
     }
   },
   "226": {
@@ -218,26 +196,6 @@
     "class_type": "LoraLoaderModelOnly",
     "_meta": {
       "title": "LoraLoaderModelOnly"
-    }
-  },
-  "361": {
-    "inputs": {
-      "brightness": -0.05,
-      "contrast": 1.1,
-      "saturation": 0.5,
-      "sharpness": 1.2,
-      "blur": 0,
-      "gaussian_blur": 0,
-      "edge_enhance": 0.3,
-      "detail_enhance": "false",
-      "image": [
-        "407",
-        0
-      ]
-    },
-    "class_type": "Image Filter Adjustments",
-    "_meta": {
-      "title": "Image Filter Adjustments"
     }
   },
   "378": {
@@ -332,7 +290,7 @@
   },
   "389": {
     "inputs": {
-      "seed": 88566838126408,
+      "seed": 1,
       "steps": 8,
       "cfg": 2,
       "sampler_name": "dpmpp_sde",
@@ -445,62 +403,10 @@
       "title": "RIFE VFI (recommend rife47 and rife49)"
     }
   },
-  "417": {
-    "inputs": {
-      "text": "\"0\" :\"6-year,litte girl，kawaii:2,short hair\",\n\"1\" :\"10-year-old,cute kid,girl\",\n\"2\" :\"16-year-old,young girl,long hair\",\n\"3\" :\"26-year-old,woman,long hair\",\n\"4\" :\"44-year-old,old woman\",\n\"5\" :\"64-year-old,old woman,gray hair\",\n\"6\" :\"84-year-old,old woman,wrinkles,white hair\",\n\"7\" :\"104-year-old,very old woman,wrinkles:2,white hair\","
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Female"
-    }
-  },
-  "418": {
-    "inputs": {
-      "text": "\"0\" :\"6-year,litte boy,kawaii:2,very short hair\",\n\"1\" :\"10-year-old,cute boy,short hair\",\n\"2\" :\"16-year-old,handsome man\",\n\"3\" :\"26-year-old,handsome man\",\n\"4\" :\"44-year-old,old man\",\n\"5\" :\"64-year-old,old man,gray hair\",\n\"6\" :\"84-year-old,old man,wrinkles,white hair\",\n\"7\" :\"104-year-old,very old man,wrinkles:2,bald,white hair\","
-    },
-    "class_type": "Text Multiline",
-    "_meta": {
-      "title": "Male"
-    }
-  },
-  "439": {
-    "inputs": {
-      "text": [
-        "489",
-        0
-      ],
-      "find": "Female",
-      "replace": [
-        "417",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "441": {
-    "inputs": {
-      "text": [
-        "439",
-        0
-      ],
-      "find": "Male",
-      "replace": [
-        "418",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
   "447": {
     "inputs": {
       "query": [
-        "492",
+        "493",
         0
       ],
       "debug": "enable",
@@ -508,7 +414,7 @@
       "model": "llava:7b-v1.6-vicuna-q8_0",
       "keep_alive": 0,
       "format": "json",
-      "seed": 735649772,
+      "seed": 1,
       "images": [
         "378",
         0
@@ -539,7 +445,7 @@
     },
     "class_type": "VixUiCheckboxLogic",
     "_meta": {
-      "title": "VixUI-CheckboxLogic"
+      "title": "Checkbox Logic (VixUI)"
     }
   },
   "454": {
@@ -552,7 +458,7 @@
       ],
       "text_b": ", ",
       "text_c": [
-        "488",
+        "501",
         0
       ]
     },
@@ -571,7 +477,7 @@
       ],
       "text_b": ", ",
       "text_c": [
-        "489",
+        "500",
         0
       ]
     },
@@ -611,7 +517,7 @@
     },
     "class_type": "VixUiRangeFloat",
     "_meta": {
-      "title": "VixUI-RangeFloat"
+      "title": "Range Float (VixUI)"
     }
   },
   "480": {
@@ -627,7 +533,7 @@
     },
     "class_type": "VixUiPrompt",
     "_meta": {
-      "title": "VixUI-Prompt"
+      "title": "Prompt (VixUI)"
     }
   },
   "481": {
@@ -640,7 +546,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/AllYourLife",
       "license": "",
       "tags": "[\"general\", \"portrait\", \"sketch\", \"video\"]",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "requires": "[\"Ollama:llava:7b-v1.6-vicuna-q8_0\"]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -652,13 +558,12 @@
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
-      "title": "VixUI-WorkflowMetadata"
+      "title": "Workflow Metadata (VixUI)"
     }
   },
   "482": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -680,7 +585,7 @@
   "486": {
     "inputs": {
       "prompt": [
-        "492",
+        "493",
         0
       ],
       "safety_settings": "BLOCK_NONE",
@@ -690,7 +595,7 @@
       "proxy": "",
       "system_instruction": "",
       "error_fallback_value": "",
-      "seed": 1966185507,
+      "seed": 1,
       "image_1": [
         "378",
         0
@@ -701,70 +606,163 @@
       "title": "Ask Gemini"
     }
   },
-  "487": {
+  "493": {
+    "inputs": {
+      "text": "Analyze the image and return one word for each, focusing only on the main person:  \n1. Race: Choose only from 'White', 'Black', 'Asian', 'Hispanic', 'Indian', or 'Neutral' (if unclear).\n2. Gender: Choose only from 'Male' or 'Female' (default to 'Female' if unclear). Do not use 'Neutral' for gender.\n\nRespond with a single dictionary, using this exact format:\n{\"Race\": \"YourRaceHere\", \"Gender\": \"YourGenderHere\"}"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "494": {
+    "inputs": {
+      "text": "\"0\" :\"6-year,litte boy,kawaii:2,very short hair\",\n\"1\" :\"10-year-old,cute boy,short hair\",\n\"2\" :\"16-year-old,handsome man\",\n\"3\" :\"26-year-old,handsome man\",\n\"4\" :\"44-year-old,old man\",\n\"5\" :\"64-year-old,old man,gray hair\",\n\"6\" :\"84-year-old,old man,wrinkles,white hair\",\n\"7\" :\"104-year-old,very old man,wrinkles:2,bald,white hair\","
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "495": {
+    "inputs": {
+      "text": "\"0\" :\"6-year,litte girl，kawaii:2,short hair\",\n\"1\" :\"10-year-old,cute kid,girl\",\n\"2\" :\"16-year-old,young girl,long hair\",\n\"3\" :\"26-year-old,woman,long hair\",\n\"4\" :\"44-year-old,old woman\",\n\"5\" :\"64-year-old,old woman,gray hair\",\n\"6\" :\"84-year-old,old woman,wrinkles,white hair\",\n\"7\" :\"104-year-old,very old woman,wrinkles:2,white hair\","
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "497": {
+    "inputs": {
+      "text": [
+        "498",
+        0
+      ],
+      "find": "Male",
+      "replace": [
+        "494",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "498": {
+    "inputs": {
+      "text": [
+        "500",
+        0
+      ],
+      "find": "Female",
+      "replace": [
+        "495",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "499": {
     "inputs": {
       "dictionary_text": [
         "452",
         0
       ]
     },
-    "class_type": "Text Dictionary Convert",
+    "class_type": "VixDictionaryConvert",
     "_meta": {
-      "title": "Text Dictionary Convert"
+      "title": "Convert to Dictionary"
     }
   },
-  "488": {
-    "inputs": {
-      "key": "Race",
-      "default_value": "Neutral",
-      "dictionary": [
-        "487",
-        0
-      ]
-    },
-    "class_type": "Text Dictionary Get",
-    "_meta": {
-      "title": "Text Dictionary Get"
-    }
-  },
-  "489": {
+  "500": {
     "inputs": {
       "key": "Gender",
       "default_value": "Female",
       "dictionary": [
-        "487",
+        "499",
         0
       ]
     },
-    "class_type": "Text Dictionary Get",
+    "class_type": "VixDictionaryGet",
     "_meta": {
-      "title": "Text Dictionary Get"
+      "title": "Dictionary Get"
     }
   },
-  "490": {
+  "501": {
+    "inputs": {
+      "key": "Race",
+      "default_value": "Neutral",
+      "dictionary": [
+        "499",
+        0
+      ]
+    },
+    "class_type": "VixDictionaryGet",
+    "_meta": {
+      "title": "Dictionary Get"
+    }
+  },
+  "503": {
     "inputs": {
       "text": [
-        "441",
+        "497",
         0
       ],
       "find": "Neutral",
       "replace": [
-        "417",
+        "495",
         0
       ]
     },
-    "class_type": "Text Find and Replace",
+    "class_type": "VixTextReplace",
     "_meta": {
-      "title": "Text Find and Replace(if LLM is dumb)"
+      "title": "Text Replace (if LLM is dumb)"
     }
   },
-  "492": {
+  "505": {
     "inputs": {
-      "text": "Analyze the image and return one word for each, focusing only on the main person:  \n1. Race: Choose only from 'White', 'Black', 'Asian', 'Hispanic', 'Indian', or 'Neutral' (if unclear).\n2. Gender: Choose only from 'Male' or 'Female' (default to 'Female' if unclear). Do not use 'Neutral' for gender.\n\nRespond with a single dictionary, using this exact format:\n{\"Race\": \"YourRaceHere\", \"Gender\": \"YourGenderHere\"}\n"
+      "brightness": -0.05,
+      "contrast": 1.1,
+      "saturation": 0.5,
+      "sharpness": 1.2,
+      "blur": 0,
+      "gaussian_blur": 0,
+      "edge_enhance": 0.3,
+      "image": [
+        "407",
+        0
+      ]
     },
-    "class_type": "Text Multiline (Code Compatible)",
+    "class_type": "VixImageFilters",
     "_meta": {
-      "title": "Text Multiline (Code Compatible)"
+      "title": "Image Filters"
+    }
+  },
+  "506": {
+    "inputs": {
+      "frame_rate": 12,
+      "loop_count": 0,
+      "filename_prefix": "ComfyUI",
+      "format": "video/h264-mp4",
+      "pix_fmt": "yuv420p",
+      "crf": 19,
+      "save_metadata": true,
+      "trim_to_audio": false,
+      "pingpong": false,
+      "save_output": true,
+      "images": [
+        "505",
+        0
+      ]
+    },
+    "class_type": "VHS_VideoCombine",
+    "_meta": {
+      "title": "Video Combine 🎥🅥🅗🅢"
     }
   }
 }

--- a/flows/colorful_xl_inpaint.json
+++ b/flows/colorful_xl_inpaint.json
@@ -385,15 +385,6 @@
       "title": "KSampler"
     }
   },
-  "325": {
-    "inputs": {
-      "text": "[\n  {\n    \"display_name\": \"ColorfulXL Redraw\",\n    \"type\": \"image-inpaint\"\n  }\n]"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "WF_SUBFLOWS"
-    }
-  },
   "326": {
     "inputs": {
       "name": "colorful_xl_inpaint",
@@ -404,13 +395,15 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/Inpaint/",
       "license": "",
       "tags": "[\"redraw\", \"postprocess\"]",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
       "is_translations_supported": true,
       "is_macos_supported": true,
-      "required_memory_gb": 6
+      "required_memory_gb": 6,
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -419,8 +412,7 @@
   },
   "327": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -429,8 +421,7 @@
   },
   "328": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -439,8 +430,7 @@
   },
   "329": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -497,6 +487,15 @@
     "class_type": "ToBinaryMask",
     "_meta": {
       "title": "ToBinaryMask"
+    }
+  },
+  "335": {
+    "inputs": {
+      "text": "[\n  {\n    \"display_name\": \"ColorfulXL Redraw\",\n    \"type\": \"image-inpaint\"\n  }\n]"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "WF_SUBFLOWS"
     }
   }
 }

--- a/flows/comicu_portrait.json
+++ b/flows/comicu_portrait.json
@@ -108,7 +108,7 @@
       ],
       "lora_clip_strength": 1,
       "positive": [
-        "399",
+        "415",
         0
       ],
       "negative": "nsfw, lowres, (bad), text, error, fewer, extra, missing, worst quality, jpeg artifacts, low quality, watermark, unfinished, displeasing, oldest, early, chromatic aberration, signature, extra digits, artistic error, username, scan, [abstract]",
@@ -207,13 +207,15 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/ComicuPortrait/",
       "license": "",
       "tags": "[\"anime\", \"portrait\"]",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
       "is_translations_supported": true,
       "is_macos_supported": true,
-      "required_memory_gb": 6
+      "required_memory_gb": 6,
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -240,8 +242,7 @@
   },
   "393": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -250,8 +251,7 @@
   },
   "394": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -272,49 +272,6 @@
     "class_type": "VixUiList",
     "_meta": {
       "title": "VixUI-List"
-    }
-  },
-  "397": {
-    "inputs": {
-      "text": [
-        "398",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "396",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "398": {
-    "inputs": {
-      "text": "[1{gender}] {prompt}, looking at viewer, half body, (masterpiece), (best quality), (ultra-detailed), very aesthetic, illustration, perfect composition"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
-  "399": {
-    "inputs": {
-      "text": [
-        "397",
-        0
-      ],
-      "find": "{prompt}",
-      "replace": [
-        "400",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
     }
   },
   "400": {
@@ -385,6 +342,49 @@
     "class_type": "VixUiCheckbox",
     "_meta": {
       "title": "VixUI-Checkbox"
+    }
+  },
+  "411": {
+    "inputs": {
+      "text": "[1{gender}] {prompt}, looking at viewer, half body, (masterpiece), (best quality), (ultra-detailed), very aesthetic, illustration, perfect composition"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "413": {
+    "inputs": {
+      "text": [
+        "411",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "396",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "415": {
+    "inputs": {
+      "text": [
+        "413",
+        0
+      ],
+      "find": "{prompt}",
+      "replace": [
+        "400",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
     }
   }
 }

--- a/flows/flux1_dev_inpaint.json
+++ b/flows/flux1_dev_inpaint.json
@@ -291,7 +291,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/Inpaint/",
       "license": "",
       "tags": "[\"redraw\", \"postprocess\"]",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -304,15 +304,6 @@
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
       "title": "VixUI-WorkflowMetadata"
-    }
-  },
-  "38": {
-    "inputs": {
-      "text": "[\n  {\n    \"display_name\": \"Flux Redraw\",\n    \"type\": \"image-inpaint\"\n  }\n]"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "WF_SUBFLOWS"
     }
   },
   "40": {
@@ -490,6 +481,15 @@
     "class_type": "VixUiList",
     "_meta": {
       "title": "VixUI-List"
+    }
+  },
+  "63": {
+    "inputs": {
+      "text": "[\n  {\n    \"display_name\": \"Flux Redraw\",\n    \"type\": \"image-inpaint\"\n  }\n]"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "WF_SUBFLOWS"
     }
   }
 }

--- a/flows/flux1_schnell_inpaint.json
+++ b/flows/flux1_schnell_inpaint.json
@@ -275,7 +275,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/Inpaint/",
       "license": "",
       "tags": "[\"redraw\", \"lighting\", \"postprocess\"]",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -288,15 +288,6 @@
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
       "title": "VixUI-WorkflowMetadata"
-    }
-  },
-  "38": {
-    "inputs": {
-      "text": "[\n  {\n    \"display_name\": \"Flux Lighting Redraw (Small)\",\n    \"type\": \"image-inpaint\"\n  }\n]"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "WF_SUBFLOWS"
     }
   },
   "40": {
@@ -469,6 +460,15 @@
     "class_type": "VixUiList",
     "_meta": {
       "title": "VixUI-List"
+    }
+  },
+  "69": {
+    "inputs": {
+      "text": "[\n  {\n    \"display_name\": \"Flux Lighting Redraw (Small)\",\n    \"type\": \"image-inpaint\"\n  }\n]"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "WF_SUBFLOWS"
     }
   }
 }

--- a/flows/ghibli_portrait.json
+++ b/flows/ghibli_portrait.json
@@ -11,7 +11,7 @@
   "290": {
     "inputs": {
       "text": [
-        "394",
+        "400",
         0
       ],
       "clip": [
@@ -196,13 +196,15 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/GhibliPortrait/",
       "license": "",
       "tags": "[\"anime\", \"portrait\"]",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
       "is_translations_supported": true,
       "is_macos_supported": true,
-      "required_memory_gb": 6
+      "required_memory_gb": 6,
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -211,8 +213,7 @@
   },
   "387": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -221,8 +222,7 @@
   },
   "389": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -245,49 +245,6 @@
       "title": "VixUI-Prompt"
     }
   },
-  "393": {
-    "inputs": {
-      "text": [
-        "395",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "396",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "394": {
-    "inputs": {
-      "text": [
-        "393",
-        0
-      ],
-      "find": "{prompt}",
-      "replace": [
-        "391",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "395": {
-    "inputs": {
-      "text": "anime, studio ghibli, ghibli style, {gender} {prompt}, split solid color background, portrait, close up, f1.2"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
   "396": {
     "inputs": {
       "default_value": "girl",
@@ -302,6 +259,49 @@
     "class_type": "VixUiList",
     "_meta": {
       "title": "VixUI-List"
+    }
+  },
+  "398": {
+    "inputs": {
+      "text": "anime, studio ghibli, ghibli style, {gender} {prompt}, split solid color background, portrait, close up, f1.2"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "399": {
+    "inputs": {
+      "text": [
+        "398",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "396",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "400": {
+    "inputs": {
+      "text": [
+        "399",
+        0
+      ],
+      "find": "{prompt}",
+      "replace": [
+        "391",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
     }
   }
 }

--- a/flows/human_face_detailer.json
+++ b/flows/human_face_detailer.json
@@ -75,6 +75,8 @@
       "cycle": 1,
       "inpaint_model": false,
       "noise_mask_feather": 0,
+      "tiled_encode": false,
+      "tiled_decode": false,
       "image": [
         "283",
         0
@@ -143,6 +145,8 @@
       "cycle": 1,
       "inpaint_model": false,
       "noise_mask_feather": 0,
+      "tiled_encode": false,
+      "tiled_decode": false,
       "image": [
         "106",
         0
@@ -211,6 +215,8 @@
       "cycle": 1,
       "inpaint_model": false,
       "noise_mask_feather": 0,
+      "tiled_encode": false,
+      "tiled_decode": false,
       "image": [
         "119",
         0
@@ -309,10 +315,15 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/HumanFaceDetailer/",
       "license": "",
       "tags": "[\"portrait\", \"postprocess\"]",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "requires": "[]",
+      "is_seed_supported": true,
+      "is_count_supported": true,
+      "is_translations_supported": false,
       "is_macos_supported": true,
-      "required_memory_gb": 8
+      "required_memory_gb": 8,
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -321,19 +332,18 @@
   },
   "283": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
       "title": "input;Image with people;order=1;custom_id=person_image"
     }
   },
-  "284": {
+  "285": {
     "inputs": {
       "text": "[\n  {\n    \"display_name\": \"Face Detailer\",\n    \"type\": \"image\"\n  }\n]"
     },
-    "class_type": "Text Multiline (Code Compatible)",
+    "class_type": "VixMultilineText",
     "_meta": {
       "title": "WF_SUBFLOWS"
     }

--- a/flows/hunyuan_img2video.json
+++ b/flows/hunyuan_img2video.json
@@ -268,15 +268,6 @@
       "title": "input;First frame;order=1;custom_id=image"
     }
   },
-  "94": {
-    "inputs": {
-      "text": "[\n  {\n    \"display_name\": \"Animate(Hunyuan-720p)\",\n    \"type\": \"image\"\n  }\n]"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "WF_SUBFLOWS"
-    }
-  },
   "95": {
     "inputs": {
       "name": "hunyuan_img2video",
@@ -287,7 +278,7 @@
       "documentation": "",
       "license": "",
       "tags": "[\"video\"]",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -378,6 +369,15 @@
     "class_type": "RemoteVAEDecode",
     "_meta": {
       "title": "VAE Decode (Remote)"
+    }
+  },
+  "101": {
+    "inputs": {
+      "text": "[\n  {\n    \"display_name\": \"Animate(Hunyuan-720p)\",\n    \"type\": \"image\"\n  }\n]"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "WF_SUBFLOWS"
     }
   }
 }

--- a/flows/ltxv_img2video.json
+++ b/flows/ltxv_img2video.json
@@ -303,14 +303,15 @@
       "documentation": "",
       "license": "",
       "tags": "[\"video\"]",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
       "is_translations_supported": true,
       "is_macos_supported": true,
       "required_memory_gb": 24,
-      "hidden": false
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -326,11 +327,11 @@
       "title": "input;First frame;order=1;custom_id=image"
     }
   },
-  "105": {
+  "106": {
     "inputs": {
       "text": "[\n  {\n    \"display_name\": \"Animate(LTXV)\",\n    \"type\": \"image\"\n  }\n]"
     },
-    "class_type": "Text Multiline (Code Compatible)",
+    "class_type": "VixMultilineText",
     "_meta": {
       "title": "WF_SUBFLOWS"
     }

--- a/flows/mad_scientist.json
+++ b/flows/mad_scientist.json
@@ -1,8 +1,7 @@
 {
   "2": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -61,8 +60,7 @@
   },
   "11": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -206,7 +204,7 @@
   "24": {
     "inputs": {
       "query": [
-        "44",
+        "51",
         0
       ],
       "debug": "enable",
@@ -335,14 +333,15 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/MadScientist/",
       "license": "",
       "tags": "[\"general\", \"portrait\"]",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "requires": "[\"Ollama:llava:7b-v1.6-vicuna-q8_0\"]",
       "is_seed_supported": true,
       "is_count_supported": true,
       "is_translations_supported": false,
       "is_macos_supported": true,
       "required_memory_gb": 6,
-      "hidden": false
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -372,15 +371,6 @@
       "title": "VixUI-CheckboxLogic"
     }
   },
-  "44": {
-    "inputs": {
-      "text": "Write a short prompt in English (less than 46 words) that defines the style (painting, 3DCG, or photography) and describes the artistic style of the image. Focus on the main subject, ignoring the background description. Only output the prompt itself."
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
   "46": {
     "inputs": {
       "upscale_method": "lanczos",
@@ -400,7 +390,7 @@
   "47": {
     "inputs": {
       "prompt": [
-        "44",
+        "51",
         0
       ],
       "safety_settings": "BLOCK_NONE",
@@ -433,6 +423,15 @@
     "class_type": "ImageScaleToTotalPixels",
     "_meta": {
       "title": "Scale Image to Total Pixels"
+    }
+  },
+  "51": {
+    "inputs": {
+      "text": "Write a short prompt in English (less than 46 words) that defines the style (painting, 3DCG, or photography) and describes the artistic style of the image. Focus on the main subject, ignoring the background description. Only output the prompt itself."
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
     }
   }
 }

--- a/flows/pencil_sketch_portrait.json
+++ b/flows/pencil_sketch_portrait.json
@@ -2,7 +2,7 @@
   "5": {
     "inputs": {
       "text": [
-        "45",
+        "63",
         0
       ],
       "clip": [
@@ -280,12 +280,12 @@
   "41": {
     "inputs": {
       "prompt": [
-        "42",
+        "62",
         0
       ],
       "safety_settings": "BLOCK_NONE",
       "response_type": "text",
-      "model": "gemini-1.5-flash-002",
+      "model": "gemini-2.0-flash-lite-001",
       "api_key": "",
       "proxy": "",
       "system_instruction": "",
@@ -301,19 +301,10 @@
       "title": "Ask Gemini"
     }
   },
-  "42": {
-    "inputs": {
-      "text": "Generate a structured caption for the given image.\n\n    Detect and describe the position of all visible subjects or objects relative to the frame.\n    Provide description of the subjects, including physical appearance, attire, accessories, and expressions.\n    Detect and transcribe visible text, specifying its position and font style.\n    Conclude with the overall mood or atmosphere.\n\nDo not describe or pay attention to the background.\n\nThe description must be accurate, comprehensive, logically organized, and contain no more than 46 words.\n"
-    },
-    "class_type": "Text Multiline",
-    "_meta": {
-      "title": "Text Multiline"
-    }
-  },
   "43": {
     "inputs": {
       "query": [
-        "42",
+        "62",
         0
       ],
       "debug": "enable",
@@ -332,33 +323,6 @@
       "title": "Ollama Vision"
     }
   },
-  "44": {
-    "inputs": {
-      "text": "pencil sketch, minimalist, impressionism, negative space"
-    },
-    "class_type": "Text Multiline",
-    "_meta": {
-      "title": "Male"
-    }
-  },
-  "45": {
-    "inputs": {
-      "delimiter": ", ",
-      "clean_whitespace": "true",
-      "text_a": [
-        "44",
-        0
-      ],
-      "text_b": [
-        "40",
-        0
-      ]
-    },
-    "class_type": "Text Concatenate",
-    "_meta": {
-      "title": "Text Concatenate"
-    }
-  },
   "46": {
     "inputs": {
       "name": "pencil_sketch_portrait",
@@ -369,7 +333,7 @@
       "documentation": "",
       "license": "",
       "tags": "[\"general\", \"portrait\", \"sketch\"]",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "requires": "[\"Ollama:llava:7b-v1.6-vicuna-q8_0\"]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -495,6 +459,42 @@
     "class_type": "VixUiList",
     "_meta": {
       "title": "VixUI-List"
+    }
+  },
+  "61": {
+    "inputs": {
+      "text": "pencil sketch, minimalist, impressionism, negative space"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "62": {
+    "inputs": {
+      "text": "Generate a structured caption for the given image.\n\n    Detect and describe the position of all visible subjects or objects relative to the frame.\n    Provide description of the subjects, including physical appearance, attire, accessories, and expressions.\n    Detect and transcribe visible text, specifying its position and font style.\n    Conclude with the overall mood or atmosphere.\n\nDo not describe or pay attention to the background.\n\nThe description must be accurate, comprehensive, logically organized, and contain no more than 46 words.\n"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "63": {
+    "inputs": {
+      "delimiter": ", ",
+      "clean_whitespace": "true",
+      "text_a": [
+        "61",
+        0
+      ],
+      "text_b": [
+        "40",
+        0
+      ]
+    },
+    "class_type": "VixTextConcatenate",
+    "_meta": {
+      "title": "Text Concatenate"
     }
   }
 }

--- a/flows/photo_stickers.json
+++ b/flows/photo_stickers.json
@@ -174,7 +174,7 @@
   "88": {
     "inputs": {
       "text": [
-        "364",
+        "407",
         0
       ],
       "clip": [
@@ -190,7 +190,7 @@
   "91": {
     "inputs": {
       "text": [
-        "366",
+        "401",
         0
       ],
       "clip": [
@@ -249,7 +249,7 @@
   "284": {
     "inputs": {
       "text": [
-        "363",
+        "408",
         0
       ],
       "clip": [
@@ -265,7 +265,7 @@
   "287": {
     "inputs": {
       "text": [
-        "367",
+        "403",
         0
       ],
       "clip": [
@@ -324,7 +324,7 @@
   "298": {
     "inputs": {
       "text": [
-        "361",
+        "406",
         0
       ],
       "clip": [
@@ -340,7 +340,7 @@
   "301": {
     "inputs": {
       "text": [
-        "368",
+        "402",
         0
       ],
       "clip": [
@@ -399,7 +399,7 @@
   "326": {
     "inputs": {
       "text": [
-        "365",
+        "405",
         0
       ],
       "clip": [
@@ -415,7 +415,7 @@
   "329": {
     "inputs": {
       "text": [
-        "369",
+        "404",
         0
       ],
       "clip": [
@@ -838,8 +838,7 @@
   },
   "358": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -856,13 +855,15 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/PhotoStickers/",
       "license": "",
       "tags": "[\"cartoon\", \"portrait\"]",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
       "is_translations_supported": false,
       "is_macos_supported": false,
-      "required_memory_gb": 8
+      "required_memory_gb": 8,
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -885,214 +886,6 @@
       "title": "VixUI-List"
     }
   },
-  "361": {
-    "inputs": {
-      "text": [
-        "371",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "362": {
-    "inputs": {
-      "text": "half body, looking at viewer, [1{gender}] laughing"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
-  "363": {
-    "inputs": {
-      "text": [
-        "370",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "364": {
-    "inputs": {
-      "text": [
-        "362",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "365": {
-    "inputs": {
-      "text": [
-        "372",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "366": {
-    "inputs": {
-      "text": [
-        "376",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "367": {
-    "inputs": {
-      "text": [
-        "374",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "368": {
-    "inputs": {
-      "text": [
-        "375",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "369": {
-    "inputs": {
-      "text": [
-        "373",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "370": {
-    "inputs": {
-      "text": "half body, looking at viewer, [1{gender}] angry, frustrated"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
-  "371": {
-    "inputs": {
-      "text": "half body, looking at viewer, [1{gender}] shocked, surprised"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
-  "372": {
-    "inputs": {
-      "text": "half body, looking at viewer, [1{gender}] happy, calm"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
-  "373": {
-    "inputs": {
-      "text": "half body, looking at viewer, [1{gender}] happy, calm, Sticker, svg, vector art, sharp, kawaii style, Anime style "
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
-  "374": {
-    "inputs": {
-      "text": "half body, looking at viewer, [1{gender}] angry, frustrated, Sticker, svg, vector art, sharp, kawaii style, Anime style "
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
-  "375": {
-    "inputs": {
-      "text": "half body, looking at viewer, [1{gender}] shocked, surprised, Sticker, svg, vector art, sharp, kawaii style, Anime style "
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
-  "376": {
-    "inputs": {
-      "text": "half body, looking at viewer, [1{gender}] laughing, Sticker, svg, vector art, sharp, kawaii style, Anime style "
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
   "381": {
     "inputs": {
       "model": [
@@ -1113,7 +906,8 @@
     "inputs": {
       "model": "General.safetensors",
       "device": "AUTO",
-      "use_weight": false
+      "use_weight": false,
+      "dtype": "float32"
     },
     "class_type": "LoadRembgByBiRefNetModel",
     "_meta": {
@@ -1166,6 +960,214 @@
     "class_type": "RembgByBiRefNet",
     "_meta": {
       "title": "RembgByBiRefNet"
+    }
+  },
+  "386": {
+    "inputs": {
+      "text": "half body, looking at viewer, [1{gender}] laughing, Sticker, svg, vector art, sharp, kawaii style, Anime style "
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "387": {
+    "inputs": {
+      "text": "half body, looking at viewer, [1{gender}] happy, calm "
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "390": {
+    "inputs": {
+      "text": "half body, looking at viewer, [1{gender}] shocked, surprised "
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "391": {
+    "inputs": {
+      "text": "half body, looking at viewer, [1{gender}] angry, frustrated "
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "393": {
+    "inputs": {
+      "text": "half body, looking at viewer, [1{gender}] shocked, surprised, Sticker, svg, vector art, sharp, kawaii style, Anime style "
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "395": {
+    "inputs": {
+      "text": "half body, looking at viewer, [1{gender}] angry, frustrated, Sticker, svg, vector art, sharp, kawaii style, Anime style "
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "397": {
+    "inputs": {
+      "text": "half body, looking at viewer, [1{gender}] happy, calm, Sticker, svg, vector art, sharp, kawaii style, Anime style "
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "399": {
+    "inputs": {
+      "text": "half body, looking at viewer, [1{gender}] laughing "
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "401": {
+    "inputs": {
+      "text": [
+        "386",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "402": {
+    "inputs": {
+      "text": [
+        "393",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "403": {
+    "inputs": {
+      "text": [
+        "395",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "404": {
+    "inputs": {
+      "text": [
+        "397",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "405": {
+    "inputs": {
+      "text": [
+        "387",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "406": {
+    "inputs": {
+      "text": [
+        "390",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "407": {
+    "inputs": {
+      "text": [
+        "399",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "408": {
+    "inputs": {
+      "text": [
+        "391",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
     }
   }
 }

--- a/flows/photo_stickers2.json
+++ b/flows/photo_stickers2.json
@@ -54,8 +54,7 @@
   },
   "326": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -107,7 +106,7 @@
       "max_frames": 4,
       "print_output": true,
       "pre_text": [
-        "547",
+        "591",
         0
       ],
       "app_text": [
@@ -315,7 +314,7 @@
   "519": {
     "inputs": {
       "query": [
-        "585",
+        "592",
         0
       ],
       "debug": "enable",
@@ -369,15 +368,6 @@
     "class_type": "Lora Loader Stack (rgthree)",
     "_meta": {
       "title": "Lora Loader Stack (rgthree)"
-    }
-  },
-  "547": {
-    "inputs": {
-      "text": ", Stickers, Sticker, chibi:1.5, flat:1.5, (full body:1.5), simple details，empty background, black background, "
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
     }
   },
   "556": {
@@ -485,14 +475,15 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/PhotoStickers2/",
       "license": "",
       "tags": "[\"cartoon\", \"portrait\"]",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "requires": "[\"Ollama:llava:7b-v1.6-vicuna-q8_0\"]",
       "is_seed_supported": true,
       "is_count_supported": true,
       "is_translations_supported": true,
       "is_macos_supported": false,
       "required_memory_gb": 16,
-      "hidden": false
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -617,19 +608,10 @@
       "title": "VixUI-CheckboxLogic"
     }
   },
-  "585": {
-    "inputs": {
-      "text": "Ignore the artistic style of the picture.\n\nDescribe the person in detail, including any interesting features or characteristics, such as gender, age, facial expression, race, color, hairstyle, hair color, hat, eye color, beard. \n\nIf it is wearing glasses, describe the style of glasses.\n\nDo not describe anything else, such as background.\n\nPlease create an image generation prompt in English less than 46 words to fit the description above."
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
   "586": {
     "inputs": {
       "prompt": [
-        "585",
+        "592",
         0
       ],
       "safety_settings": "BLOCK_NONE",
@@ -690,6 +672,24 @@
     "class_type": "ImageScaleToTotalPixels",
     "_meta": {
       "title": "Scale Image to Total Pixels"
+    }
+  },
+  "591": {
+    "inputs": {
+      "text": ", Stickers, Sticker, chibi:1.5, flat:1.5, (full body:1.5), simple details，empty background, black background, "
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "592": {
+    "inputs": {
+      "text": "Ignore the artistic style of the picture.\n\nDescribe the person in detail, including any interesting features or characteristics, such as gender, age, facial expression, race, color, hairstyle, hair color, hat, eye color, beard. \n\nIf it is wearing glasses, describe the style of glasses.\n\nDo not describe anything else, such as background.\n\nPlease create an image generation prompt in English less than 46 words to fit the description above."
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
     }
   }
 }

--- a/flows/photomaker_1.json
+++ b/flows/photomaker_1.json
@@ -22,7 +22,7 @@
   "6": {
     "inputs": {
       "text": [
-        "127",
+        "134",
         0
       ],
       "clip": [
@@ -38,7 +38,7 @@
   "7": {
     "inputs": {
       "text": [
-        "120",
+        "138",
         0
       ],
       "clip": [
@@ -186,7 +186,7 @@
   "73": {
     "inputs": {
       "text": [
-        "118",
+        "137",
         0
       ],
       "photomaker": [
@@ -288,13 +288,15 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/Photomaker_1/",
       "license": "",
       "tags": "[\"general\", \"portrait\", \"cartoon\"]",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
       "is_translations_supported": true,
       "is_macos_supported": true,
-      "required_memory_gb": 6
+      "required_memory_gb": 6,
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -303,8 +305,7 @@
   },
   "100": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -345,142 +346,6 @@
       "title": "VixUI-List"
     }
   },
-  "108": {
-    "inputs": {
-      "key": [
-        "107",
-        0
-      ],
-      "default_value": "",
-      "dictionary": [
-        "113",
-        0
-      ]
-    },
-    "class_type": "Text Dictionary Get",
-    "_meta": {
-      "title": "Text Dictionary Get"
-    }
-  },
-  "112": {
-    "inputs": {
-      "key_1": "Cinematic",
-      "value_1": "{negative_prompt}, anime, cartoon, graphic, text, painting, crayon, graphite, abstract, glitch, deformed, mutated, ugly, disfigured",
-      "key_2": "Disney Character",
-      "value_2": "{negative_prompt}, lowres, bad anatomy, bad hands, text, bad eyes, bad arms, bad legs, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, blurry, grayscale, noisy, sloppy, messy, grainy, highly detailed, ultra textured, photo",
-      "key_3": "Digital Art",
-      "value_3": "{negative_prompt}, photo, photorealistic, realism, ugly",
-      "key_4": "Photographic",
-      "value_4": "{negative_prompt}, drawing, painting, crayon, sketch, graphite, impressionist, noisy, blurry, soft, deformed, ugly",
-      "key_5": "Fantasy art",
-      "value_5": "{negative_prompt}, photographic, realistic, realism, 35mm film, dslr, cropped, frame, text, deformed, glitch, noise, noisy, off-center, deformed, cross-eyed, closed eyes, bad anatomy, ugly, disfigured, sloppy, duplicate, mutated, black and white"
-    },
-    "class_type": "Text Dictionary New",
-    "_meta": {
-      "title": "Text Dictionary New"
-    }
-  },
-  "113": {
-    "inputs": {
-      "dictionary_a": [
-        "112",
-        0
-      ],
-      "dictionary_b": [
-        "114",
-        0
-      ]
-    },
-    "class_type": "Text Dictionary Update",
-    "_meta": {
-      "title": "Text Dictionary Update"
-    }
-  },
-  "114": {
-    "inputs": {
-      "key_1": "Neonpunk",
-      "value_1": "{negative_prompt}, painting, drawing, illustration, glitch, deformed, mutated, cross-eyed, ugly, disfigured",
-      "key_2": "Comic book",
-      "value_2": "{negative_prompt}, photograph, deformed, glitch, noisy, realistic, stock photo",
-      "key_3": "Lowpoly",
-      "value_3": "{negative_prompt}, noisy, sloppy, messy, grainy, highly detailed, ultra textured, photo",
-      "key_4": "Line art",
-      "value_4": "{negative_prompt}, anime, photorealistic, 35mm film, deformed, glitch, blurry, noisy, off-center, deformed, cross-eyed, closed eyes, bad anatomy, ugly, disfigured, mutated, realism, realistic, impressionism, expressionism, oil, acrylic",
-      "key_5": "",
-      "value_5": ""
-    },
-    "class_type": "Text Dictionary New",
-    "_meta": {
-      "title": "Text Dictionary New"
-    }
-  },
-  "117": {
-    "inputs": {
-      "dictionary_a": [
-        "129",
-        0
-      ],
-      "dictionary_b": [
-        "131",
-        0
-      ]
-    },
-    "class_type": "Text Dictionary Update",
-    "_meta": {
-      "title": "Text Dictionary Update"
-    }
-  },
-  "118": {
-    "inputs": {
-      "text": [
-        "119",
-        0
-      ],
-      "find": "{prompt}",
-      "replace": [
-        "122",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "119": {
-    "inputs": {
-      "key": [
-        "107",
-        0
-      ],
-      "default_value": "",
-      "dictionary": [
-        "117",
-        0
-      ]
-    },
-    "class_type": "Text Dictionary Get",
-    "_meta": {
-      "title": "Text Dictionary Get"
-    }
-  },
-  "120": {
-    "inputs": {
-      "text": [
-        "108",
-        0
-      ],
-      "find": "{negative_prompt}",
-      "replace": [
-        "123",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
   "122": {
     "inputs": {
       "text": "portrait of girl",
@@ -513,73 +378,6 @@
       "title": "VixUI-Prompt"
     }
   },
-  "126": {
-    "inputs": {
-      "text": [
-        "119",
-        0
-      ],
-      "find": ", photomaker",
-      "replace": ""
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "127": {
-    "inputs": {
-      "text": [
-        "126",
-        0
-      ],
-      "find": "{prompt}",
-      "replace": [
-        "122",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
-  "129": {
-    "inputs": {
-      "key_1": "Cinematic",
-      "value_1": "cinematic still {prompt} . emotional, harmonious, vignette, highly detailed, high budget, bokeh, cinemascope, moody, epic, gorgeous, film grain, grainy, photomaker",
-      "key_2": "Disney Character",
-      "value_2": "Pixar animation character of {prompt} . pixar-style, studio anime, Disney, high-quality, photomaker",
-      "key_3": "Digital Art",
-      "value_3": "concept art {prompt} . digital artwork, illustrative, painterly, matte painting, highly detailed, photomaker",
-      "key_4": "Photographic",
-      "value_4": "cinematic photo {prompt} . 35mm photograph, film, bokeh, professional, 4k, highly detailed, photomaker",
-      "key_5": "Fantasy art",
-      "value_5": "ethereal fantasy concept art of {prompt} . magnificent, celestial, ethereal, painterly, epic, majestic, magical, fantasy art, cover art, dreamy, photomaker"
-    },
-    "class_type": "Text Dictionary New",
-    "_meta": {
-      "title": "Text Dictionary New"
-    }
-  },
-  "131": {
-    "inputs": {
-      "key_1": "Neonpunk",
-      "value_1": "neonpunk style {prompt} . cyberpunk, vaporwave, neon, vibes, vibrant, stunningly beautiful, crisp, detailed, sleek, ultramodern, magenta highlights, dark purple shadows, high contrast, cinematic, ultra detailed, intricate, professional, photomaker",
-      "key_2": "Comic book",
-      "value_2": "comic {prompt} . graphic illustration, comic art, graphic novel art, vibrant, highly detailed, photomaker",
-      "key_3": "Lowpoly",
-      "value_3": "low-poly style {prompt} . low-poly game art, polygon mesh, jagged, blocky, wireframe edges, centered composition, photomaker",
-      "key_4": "Line art",
-      "value_4": "line art drawing {prompt} . professional, sleek, modern, minimalist, graphic, line art, vector graphics, photomaker",
-      "key_5": "",
-      "value_5": ""
-    },
-    "class_type": "Text Dictionary New",
-    "_meta": {
-      "title": "Text Dictionary New"
-    }
-  },
   "133": {
     "inputs": {
       "number_of_faces": 1,
@@ -596,6 +394,157 @@
     "class_type": "AutoCropFaces",
     "_meta": {
       "title": "Auto Crop Faces"
+    }
+  },
+  "134": {
+    "inputs": {
+      "text": [
+        "135",
+        0
+      ],
+      "find": "{prompt}",
+      "replace": [
+        "122",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "135": {
+    "inputs": {
+      "text": [
+        "140",
+        0
+      ],
+      "find": ", photomaker",
+      "replace": ""
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "137": {
+    "inputs": {
+      "text": [
+        "140",
+        0
+      ],
+      "find": "{prompt}",
+      "replace": [
+        "122",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "138": {
+    "inputs": {
+      "text": [
+        "139",
+        0
+      ],
+      "find": "{negative_prompt}",
+      "replace": [
+        "123",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "139": {
+    "inputs": {
+      "key": [
+        "107",
+        0
+      ],
+      "default_value": "",
+      "dictionary": [
+        "141",
+        0
+      ]
+    },
+    "class_type": "VixDictionaryGet",
+    "_meta": {
+      "title": "Dictionary Get"
+    }
+  },
+  "140": {
+    "inputs": {
+      "key": [
+        "107",
+        0
+      ],
+      "default_value": "",
+      "dictionary": [
+        "143",
+        0
+      ]
+    },
+    "class_type": "VixDictionaryGet",
+    "_meta": {
+      "title": "Dictionary Get"
+    }
+  },
+  "141": {
+    "inputs": {
+      "key_1": "Cinematic",
+      "value_1": "{negative_prompt}, anime, cartoon, graphic, text, painting, crayon, graphite, abstract, glitch, deformed, mutated, ugly, disfigured",
+      "key_2": "Disney Character",
+      "value_2": "{negative_prompt}, lowres, bad anatomy, bad hands, text, bad eyes, bad arms, bad legs, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, blurry, grayscale, noisy, sloppy, messy, grainy, highly detailed, ultra textured, photo",
+      "key_3": "Digital Art",
+      "value_3": "{negative_prompt}, photo, photorealistic, realism, ugly",
+      "key_4": "Photographic",
+      "value_4": "{negative_prompt}, drawing, painting, crayon, sketch, graphite, impressionist, noisy, blurry, soft, deformed, ugly",
+      "key_5": "Fantasy art",
+      "value_5": "{negative_prompt}, photographic, realistic, realism, 35mm film, dslr, cropped, frame, text, deformed, glitch, noise, noisy, off-center, deformed, cross-eyed, closed eyes, bad anatomy, ugly, disfigured, sloppy, duplicate, mutated, black and white",
+      "key_6": "Neonpunk",
+      "value_6": "{negative_prompt}, painting, drawing, illustration, glitch, deformed, mutated, cross-eyed, ugly, disfigured",
+      "key_7": "Comic book",
+      "value_7": "{negative_prompt}, photograph, deformed, glitch, noisy, realistic, stock photo",
+      "key_8": "Lowpoly",
+      "value_8": "{negative_prompt}, noisy, sloppy, messy, grainy, highly detailed, ultra textured, photo",
+      "key_9": "Line art",
+      "value_9": "{negative_prompt}, anime, photorealistic, 35mm film, deformed, glitch, blurry, noisy, off-center, deformed, cross-eyed, closed eyes, bad anatomy, ugly, disfigured, mutated, realism, realistic, impressionism, expressionism, oil, acrylic"
+    },
+    "class_type": "VixDictionaryNew",
+    "_meta": {
+      "title": "Dictionary New"
+    }
+  },
+  "143": {
+    "inputs": {
+      "key_1": "Cinematic",
+      "value_1": "cinematic still {prompt} . emotional, harmonious, vignette, highly detailed, high budget, bokeh, cinemascope, moody, epic, gorgeous, film grain, grainy, photomaker",
+      "key_2": "Disney Character",
+      "value_2": "Pixar animation character of {prompt} . pixar-style, studio anime, Disney, high-quality, photomaker",
+      "key_3": "Digital Art",
+      "value_3": "concept art {prompt} . digital artwork, illustrative, painterly, matte painting, highly detailed, photomaker",
+      "key_4": "Photographic",
+      "value_4": "cinematic photo {prompt} . 35mm photograph, film, bokeh, professional, 4k, highly detailed, photomaker",
+      "key_5": "Fantasy art",
+      "value_5": "ethereal fantasy concept art of {prompt} . magnificent, celestial, ethereal, painterly, epic, majestic, magical, fantasy art, cover art, dreamy, photomaker",
+      "key_6": "Neonpunk",
+      "value_6": "neonpunk style {prompt} . cyberpunk, vaporwave, neon, vibes, vibrant, stunningly beautiful, crisp, detailed, sleek, ultramodern, magenta highlights, dark purple shadows, high contrast, cinematic, ultra detailed, intricate, professional, photomaker",
+      "key_7": "Comic book",
+      "value_7": "comic {prompt} . graphic illustration, comic art, graphic novel art, vibrant, highly detailed, photomaker",
+      "key_8": "Lowpoly",
+      "value_8": "low-poly style {prompt} . low-poly game art, polygon mesh, jagged, blocky, wireframe edges, centered composition, photomaker",
+      "key_9": "Line art",
+      "value_9": "line art drawing {prompt} . professional, sleek, modern, minimalist, graphic, line art, vector graphics, photomaker"
+    },
+    "class_type": "VixDictionaryNew",
+    "_meta": {
+      "title": "Dictionary New"
     }
   }
 }

--- a/flows/remove_background_birefnet.json
+++ b/flows/remove_background_birefnet.json
@@ -22,15 +22,6 @@
       "title": "Save Image"
     }
   },
-  "15": {
-    "inputs": {
-      "text": "[\n  {\n    \"display_name\": \"Remove background (BiRefNet)\"\n,    \"type\": \"image\"\n  }\n]"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "WF_SUBFLOWS"
-    }
-  },
   "16": {
     "inputs": {
       "name": "remove_background_birefnet",
@@ -41,13 +32,15 @@
       "documentation": "",
       "license": "",
       "tags": "[\"background\", \"postprocess\"]",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "requires": "[]",
       "is_seed_supported": false,
       "is_count_supported": false,
       "is_translations_supported": false,
       "is_macos_supported": false,
-      "required_memory_gb": 6
+      "required_memory_gb": 6,
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -74,11 +67,21 @@
     "inputs": {
       "model": "General.safetensors",
       "device": "AUTO",
-      "use_weight": false
+      "use_weight": false,
+      "dtype": "float32"
     },
     "class_type": "LoadRembgByBiRefNetModel",
     "_meta": {
       "title": "LoadRembgByBiRefNetModel"
+    }
+  },
+  "25": {
+    "inputs": {
+      "text": "[\n  {\n    \"display_name\": \"Remove background (BiRefNet)\"\n,    \"type\": \"image\"\n  }\n]"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "WF_SUBFLOWS"
     }
   }
 }

--- a/flows/remove_background_birefnet_lite.json
+++ b/flows/remove_background_birefnet_lite.json
@@ -22,15 +22,6 @@
       "title": "Save Image"
     }
   },
-  "15": {
-    "inputs": {
-      "text": "[\n  {\n    \"display_name\": \"Remove background (BiRefNet Lite)\"\n,    \"type\": \"image\"\n  }\n]"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "WF_SUBFLOWS"
-    }
-  },
   "16": {
     "inputs": {
       "name": "remove_background_birefnet_lite",
@@ -41,13 +32,15 @@
       "documentation": "",
       "license": "",
       "tags": "[\"background\", \"postprocess\"]",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "requires": "[]",
       "is_seed_supported": false,
       "is_count_supported": false,
       "is_translations_supported": false,
       "is_macos_supported": false,
-      "required_memory_gb": 4
+      "required_memory_gb": 4,
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -74,11 +67,21 @@
     "inputs": {
       "model": "General-Lite.safetensors",
       "device": "AUTO",
-      "use_weight": false
+      "use_weight": false,
+      "dtype": "float32"
     },
     "class_type": "LoadRembgByBiRefNetModel",
     "_meta": {
       "title": "LoadRembgByBiRefNetModel"
+    }
+  },
+  "25": {
+    "inputs": {
+      "text": "[\n  {\n    \"display_name\": \"Remove background (BiRefNet Lite)\"\n,    \"type\": \"image\"\n  }\n]"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "WF_SUBFLOWS"
     }
   }
 }

--- a/flows/remove_background_bria.json
+++ b/flows/remove_background_bria.json
@@ -9,26 +9,19 @@
       "documentation": "",
       "license": "",
       "tags": "[\"background\", \"postprocess\"]",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "requires": "[]",
       "is_seed_supported": false,
       "is_count_supported": false,
       "is_translations_supported": false,
       "is_macos_supported": false,
-      "required_memory_gb": 6
+      "required_memory_gb": 6,
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
       "title": "VixUI-WorkflowMetadata"
-    }
-  },
-  "314": {
-    "inputs": {
-      "text": "[\n  {\n    \"display_name\": \"Remove background (Bria)\"\n,    \"type\": \"image\"\n  }\n]"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "WF_SUBFLOWS"
     }
   },
   "319": {
@@ -58,7 +51,8 @@
     "inputs": {
       "model": "bria-rmbg-2.safetensors",
       "device": "AUTO",
-      "use_weight": false
+      "use_weight": false,
+      "dtype": "float32"
     },
     "class_type": "LoadRembgByBiRefNetModel",
     "_meta": {
@@ -79,6 +73,15 @@
     "class_type": "RembgByBiRefNet",
     "_meta": {
       "title": "RembgByBiRefNet"
+    }
+  },
+  "323": {
+    "inputs": {
+      "text": "[\n  {\n    \"display_name\": \"Remove background (Bria)\"\n,    \"type\": \"image\"\n  }\n]"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "WF_SUBFLOWS"
     }
   }
 }

--- a/flows/sketch_pencil.json
+++ b/flows/sketch_pencil.json
@@ -2,7 +2,7 @@
   "6": {
     "inputs": {
       "text": [
-        "67",
+        "86",
         0
       ],
       "clip": [
@@ -157,28 +157,6 @@
       "title": "Load LoRA"
     }
   },
-  "67": {
-    "inputs": {
-      "delimiter": ", ",
-      "clean_whitespace": "false",
-      "text_a": [
-        "69",
-        0
-      ],
-      "text_b": [
-        "70",
-        0
-      ],
-      "text_c": [
-        "72",
-        0
-      ]
-    },
-    "class_type": "Text Concatenate",
-    "_meta": {
-      "title": "Text Concatenate"
-    }
-  },
   "68": {
     "inputs": {
       "name": "sketch_pencil",
@@ -189,7 +167,7 @@
       "documentation": "",
       "license": "",
       "tags": "[\"general\", \"sketch\"]",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -220,15 +198,6 @@
       "title": "VixUI-Prompt"
     }
   },
-  "70": {
-    "inputs": {
-      "text": "shou_xin"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
   "71": {
     "inputs": {
       "value": 1,
@@ -245,15 +214,6 @@
     "class_type": "VixUiRangeFloat",
     "_meta": {
       "title": "VixUI-RangeFloat"
-    }
-  },
-  "72": {
-    "inputs": {
-      "text": "minimalist"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
     }
   },
   "74": {
@@ -349,6 +309,46 @@
     "class_type": "VixUiList",
     "_meta": {
       "title": "VixUI-List"
+    }
+  },
+  "81": {
+    "inputs": {
+      "text": "shou_xin"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "85": {
+    "inputs": {
+      "text": "minimalist"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "86": {
+    "inputs": {
+      "delimiter": ", ",
+      "clean_whitespace": "true",
+      "text_a": [
+        "69",
+        0
+      ],
+      "text_b": [
+        "81",
+        0
+      ],
+      "text_c": [
+        "85",
+        0
+      ]
+    },
+    "class_type": "VixTextConcatenate",
+    "_meta": {
+      "title": "Text Concatenate"
     }
   }
 }

--- a/flows/sketch_portrait.json
+++ b/flows/sketch_portrait.json
@@ -11,7 +11,7 @@
   "290": {
     "inputs": {
       "text": [
-        "401",
+        "406",
         0
       ],
       "clip": [
@@ -238,13 +238,15 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/SketchPortrait/",
       "license": "",
       "tags": "[\"anime\", \"sketch\", \"portrait\"]",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
       "is_translations_supported": true,
       "is_macos_supported": true,
-      "required_memory_gb": 6
+      "required_memory_gb": 6,
+      "hidden": false,
+      "remote_vae": false
     },
     "class_type": "VixUiWorkflowMetadata",
     "_meta": {
@@ -253,8 +255,7 @@
   },
   "394": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -263,8 +264,7 @@
   },
   "396": {
     "inputs": {
-      "image": "",
-      "upload": "image"
+      "image": ""
     },
     "class_type": "LoadImage",
     "_meta": {
@@ -287,32 +287,6 @@
       "title": "VixUI-List"
     }
   },
-  "398": {
-    "inputs": {
-      "text": "[1{gender}] {prompt}, line-sketch, ((looking at viewer, clear background, white background)), best quality"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "Text Multiline (Code Compatible)"
-    }
-  },
-  "399": {
-    "inputs": {
-      "text": [
-        "398",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "397",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
-    }
-  },
   "400": {
     "inputs": {
       "text": "",
@@ -327,23 +301,6 @@
     "class_type": "VixUiPrompt",
     "_meta": {
       "title": "VixUI-Prompt"
-    }
-  },
-  "401": {
-    "inputs": {
-      "text": [
-        "399",
-        0
-      ],
-      "find": "{prompt}",
-      "replace": [
-        "400",
-        0
-      ]
-    },
-    "class_type": "Text Find and Replace",
-    "_meta": {
-      "title": "Text Find and Replace"
     }
   },
   "402": {
@@ -380,6 +337,49 @@
     "class_type": "VixUiRangeFloat",
     "_meta": {
       "title": "VixUI-RangeFloat"
+    }
+  },
+  "405": {
+    "inputs": {
+      "text": "[1{gender}] {prompt}, line-sketch, ((looking at viewer, clear background, white background)), best quality"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "Text Multiline"
+    }
+  },
+  "406": {
+    "inputs": {
+      "text": [
+        "407",
+        0
+      ],
+      "find": "{prompt}",
+      "replace": [
+        "400",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
+    }
+  },
+  "407": {
+    "inputs": {
+      "text": [
+        "405",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "397",
+        0
+      ]
+    },
+    "class_type": "VixTextReplace",
+    "_meta": {
+      "title": "Text Replace"
     }
   }
 }

--- a/flows/supir_upscaler.json
+++ b/flows/supir_upscaler.json
@@ -316,15 +316,6 @@
       "title": "Evaluate Integers"
     }
   },
-  "112": {
-    "inputs": {
-      "text": "[\n  {\n    \"display_name\": \"SUPIR(1.5x)\",\n    \"type\": \"image\",\n    \"input_params\": [\n      {\n        \"name\": \"scale_factor\",\n        \"default\": 1.5\n      }\n    ]\n  },\n  {\n    \"display_name\": \"SUPIR(2x)\",\n    \"type\": \"image\",\n    \"input_params\": [\n      {\n        \"name\": \"scale_factor\",\n        \"default\": 2.0\n      }\n    ]\n  }\n]"
-    },
-    "class_type": "Text Multiline (Code Compatible)",
-    "_meta": {
-      "title": "WF_SUBFLOWS"
-    }
-  },
   "113": {
     "inputs": {
       "name": "supir_upscaler",
@@ -335,7 +326,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/SupirUpscaler/",
       "license": "",
       "tags": "[\"upscaler\", \"postprocess\"]",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -492,6 +483,15 @@
     "class_type": "VixUiRangeInt",
     "_meta": {
       "title": "VixUI-RangeInt"
+    }
+  },
+  "148": {
+    "inputs": {
+      "text": "[\n  {\n    \"display_name\": \"SUPIR(1.5x)\",\n    \"type\": \"image\",\n    \"input_params\": [\n      {\n        \"name\": \"scale_factor\",\n        \"default\": 1.5\n      }\n    ]\n  },\n  {\n    \"display_name\": \"SUPIR(2x)\",\n    \"type\": \"image\",\n    \"input_params\": [\n      {\n        \"name\": \"scale_factor\",\n        \"default\": 2.0\n      }\n    ]\n  }\n]"
+    },
+    "class_type": "VixMultilineText",
+    "_meta": {
+      "title": "WF_SUBFLOWS"
     }
   }
 }


### PR DESCRIPTION
From WAS-Node-Suite we use only `text`/`dict` nodes(_it is a pity that ComfyUI have no such built-in nodes as standard_) and `ImageFilter`.

Yesterday I made a few commits implementing(_from scratch, not a copy-paste_) all that in our [ComfyUI-Visionatrix](https://github.com/Visionatrix/ComfyUI-Visionatrix) node.

Tried to keep existing behavior as much as possible and after that I changed all our flows to use that new nodes.

We will not drop `WAS-Node-Suite` for this upcoming version, but one version later we will probably stop installing it by default(it is not greatly supported and it is the slowest node pack that I see in speed load times)