### PR TITLE
update models for ComfyUI InfiniteYou to official versions

### DIFF
--- a/models_catalog.json
+++ b/models_catalog.json
@@ -1538,13 +1538,14 @@
   "InfiniteYou-ControlNet-Similarity": {
     "regexes": [
       {
-        "input_value": "(?i)(?:[^\\/\\\\]*[\\/\\\\]?)?sim_stage1_control_net\\.safetensors$"
+        "input_value": "(?i)(?:[^\\/\\\\]*[\\/\\\\]?)?(?:sim_stage1_control_net\\.safetensors|infusenet_sim_bf16\\.safetensors)$"
       }
     ],
-    "url": "https://huggingface.co/vuongminhkhoi4/ComfyUI_InfiniteYou/resolve/main/sim_stage1_control_net/sim_stage1_control_net.safetensors",
-    "homepage": "https://huggingface.co/vuongminhkhoi4/ComfyUI_InfiniteYou",
-    "hash": "8ee8efc6d6e4eb746ea4634318a09c96f4b7c61318d04e644a5351f6e26b5fb5",
-    "file_size": 5905345320,
+    "url": "https://huggingface.co/ByteDance/InfiniteYou/resolve/main/infu_flux_v1.0/sim_stage1/infusenet_sim_bf16.safetensors",
+    "homepage": "https://huggingface.co/ByteDance/InfiniteYou",
+    "hash": "55f76b4ade8eea689e9a1dc1720a2d8dbd93efe843de8721f17fb2ab828d35f2",
+    "file_size": 5905345288,
+    "filename": "sim_stage1_control_net.safetensors",
     "types": [
       "controlnet"
     ]
@@ -1555,10 +1556,11 @@
         "input_value": "(?i)(?:[^\\/\\\\]*[\\/\\\\]?)?sim_stage1_img_proj\\.bin$"
       }
     ],
-    "url": "https://huggingface.co/vuongminhkhoi4/ComfyUI_InfiniteYou/resolve/main/sim_stage1_control_net/sim_stage1_img_proj.bin",
-    "homepage": "https://huggingface.co/vuongminhkhoi4/ComfyUI_InfiniteYou",
+    "url": "https://huggingface.co/ByteDance/InfiniteYou/resolve/main/infu_flux_v1.0/sim_stage1/image_proj_model.bin",
+    "homepage": "https://huggingface.co/ByteDance/InfiniteYou",
     "hash": "b7a8a1b6fecf2731b2ac64bde33a1885014949c8c08f3efaebd0665bb0e8ad8f",
     "file_size": 338413026,
+    "filename": "sim_stage1_img_proj.bin",
     "types": [
       "InfiniteYou"
     ]
@@ -1566,13 +1568,14 @@
   "InfiniteYou-ControlNet-Aesthetics": {
     "regexes": [
       {
-        "input_value": "(?i)(?:[^\\/\\\\]*[\\/\\\\]?)?aes_stage2_control\\.safetensors$"
+        "input_value": "(?i)(?:[^\\/\\\\]*[\\/\\\\]?)?(?:aes_stage2_control\\.safetensors|infusenet_aes_bf16\\.safetensors)$"
       }
     ],
-    "url": "https://huggingface.co/vuongminhkhoi4/ComfyUI_InfiniteYou/resolve/main/aes_stage2_control_net/aes_stage2_control.safetensors",
-    "homepage": "https://huggingface.co/vuongminhkhoi4/ComfyUI_InfiniteYou",
-    "hash": "62ec6e658775747ae2eea8abec8af30eb92b74a57ce0a7087693d3381626e727",
-    "file_size": 5905345320,
+    "url": "https://huggingface.co/ByteDance/InfiniteYou/resolve/main/infu_flux_v1.0/aes_stage2/infusenet_aes_bf16.safetensors",
+    "homepage": "https://huggingface.co/ByteDance/InfiniteYou",
+    "hash": "c31d2ae3bf3263aeb6b8221193f0c5a83115ccb0e5170f798a40fc53ec5d7a53",
+    "file_size": 5905345288,
+    "filename": "aes_stage2_control.safetensors",
     "types": [
       "controlnet"
     ]
@@ -1583,10 +1586,11 @@
         "input_value": "(?i)(?:[^\\/\\\\]*[\\/\\\\]?)?aes_stage2_img_proj\\.bin$"
       }
     ],
-    "url": "https://huggingface.co/vuongminhkhoi4/ComfyUI_InfiniteYou/resolve/main/aes_stage2_control_net/aes_stage2_img_proj.bin",
-    "homepage": "https://huggingface.co/vuongminhkhoi4/ComfyUI_InfiniteYou",
+    "url": "https://huggingface.co/ByteDance/InfiniteYou/resolve/main/infu_flux_v1.0/aes_stage2/image_proj_model.bin",
+    "homepage": "https://huggingface.co/ByteDance/InfiniteYou",
     "hash": "f85518431d7367de30b9558a939c003462a7e331e8c8b929146916dc27e471d6",
     "file_size": 338413026,
+    "filename": "aes_stage2_img_proj.bin",
     "types": [
       "InfiniteYou"
     ]


### PR DESCRIPTION
1. We will not switch to official node, as unofficial one works fine.
2. We just switch to the official ByteDance models, as they are a bit better from testing on ~50 images.
