### PR TITLE
chore: use StringConcatenate instead of VixTextConcatenate

### DIFF
--- a/flows/animal_clothing.json
+++ b/flows/animal_clothing.json
@@ -2,7 +2,7 @@
   "6": {
     "inputs": {
       "text": [
-        "102",
+        "109",
         0
       ],
       "clip": [
@@ -201,7 +201,7 @@
   "75": {
     "inputs": {
       "prompt": [
-        "107",
+        "113",
         0
       ],
       "debug": "enable",
@@ -226,7 +226,7 @@
       "documentation": "",
       "license": "",
       "tags": "[\"general\", \"animals\", \"clothing\"]",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "requires": "[\"Ollama: gemma3:12b-it-qat\"]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -285,7 +285,7 @@
   "87": {
     "inputs": {
       "prompt": [
-        "108",
+        "110",
         0
       ],
       "safety_settings": "BLOCK_NONE",
@@ -295,7 +295,9 @@
       "proxy": "",
       "system_instruction": "",
       "error_fallback_value": "",
-      "seed": 1
+      "seed": 1,
+      "temperature": -0.05,
+      "num_predict": 0
     },
     "class_type": "Ask_Gemini",
     "_meta": {
@@ -316,6 +318,8 @@
       "system_instruction": "",
       "error_fallback_value": "",
       "seed": 1,
+      "temperature": -0.05,
+      "num_predict": 0,
       "image_1": [
         "81",
         0
@@ -340,6 +344,8 @@
       "system_instruction": "",
       "error_fallback_value": "",
       "seed": 1,
+      "temperature": -0.05,
+      "num_predict": 0,
       "image_1": [
         "82",
         0
@@ -445,24 +451,6 @@
       "title": "VAE Decode (Remote)"
     }
   },
-  "102": {
-    "inputs": {
-      "delimiter": ", ",
-      "clean_whitespace": "true",
-      "text_a": [
-        "103",
-        0
-      ],
-      "text_b": [
-        "86",
-        0
-      ]
-    },
-    "class_type": "VixTextConcatenate",
-    "_meta": {
-      "title": "Text Concatenate"
-    }
-  },
   "103": {
     "inputs": {
       "text": " fashion magazine shoots, aidmafluxpro1.1, solo,"
@@ -499,48 +487,89 @@
       "title": "Text Multiline"
     }
   },
-  "107": {
+  "109": {
     "inputs": {
-      "delimiter": ", ",
-      "clean_whitespace": "true",
-      "text_a": [
-        "106",
+      "string_a": [
+        "103",
         0
       ],
-      "text_b": [
-        "68",
+      "string_b": [
+        "86",
         0
       ],
-      "text_c": [
-        "69",
-        0
-      ]
+      "delimiter": ", "
     },
-    "class_type": "VixTextConcatenate",
+    "class_type": "StringConcatenate",
     "_meta": {
-      "title": "Text Concatenate"
+      "title": "Concatenate"
     }
   },
-  "108": {
+  "110": {
     "inputs": {
-      "delimiter": ", ",
-      "clean_whitespace": "true",
-      "text_a": [
+      "string_a": [
+        "111",
+        0
+      ],
+      "string_b": [
+        "89",
+        0
+      ],
+      "delimiter": ", "
+    },
+    "class_type": "StringConcatenate",
+    "_meta": {
+      "title": "Concatenate"
+    }
+  },
+  "111": {
+    "inputs": {
+      "string_a": [
         "106",
         0
       ],
-      "text_b": [
+      "string_b": [
         "90",
         0
       ],
-      "text_c": [
-        "89",
-        0
-      ]
+      "delimiter": ", "
     },
-    "class_type": "VixTextConcatenate",
+    "class_type": "StringConcatenate",
     "_meta": {
-      "title": "Text Concatenate"
+      "title": "Concatenate"
+    }
+  },
+  "112": {
+    "inputs": {
+      "string_a": [
+        "106",
+        0
+      ],
+      "string_b": [
+        "68",
+        0
+      ],
+      "delimiter": ", "
+    },
+    "class_type": "StringConcatenate",
+    "_meta": {
+      "title": "Concatenate"
+    }
+  },
+  "113": {
+    "inputs": {
+      "string_a": [
+        "112",
+        0
+      ],
+      "string_b": [
+        "69",
+        0
+      ],
+      "delimiter": ", "
+    },
+    "class_type": "StringConcatenate",
+    "_meta": {
+      "title": "Concatenate"
     }
   }
 }

--- a/flows/pencil_sketch_portrait.json
+++ b/flows/pencil_sketch_portrait.json
@@ -2,7 +2,7 @@
   "5": {
     "inputs": {
       "text": [
-        "63",
+        "68",
         0
       ],
       "clip": [
@@ -291,6 +291,8 @@
       "system_instruction": "",
       "error_fallback_value": "",
       "seed": 1,
+      "temperature": -0.05,
+      "num_predict": 0,
       "image_1": [
         "37",
         0
@@ -333,7 +335,7 @@
       "documentation": "",
       "license": "",
       "tags": "[\"general\", \"portrait\", \"sketch\"]",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "requires": "[\"Ollama: gemma3:12b-it-qat\"]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -455,24 +457,6 @@
       "title": "Text Multiline"
     }
   },
-  "63": {
-    "inputs": {
-      "delimiter": ", ",
-      "clean_whitespace": "true",
-      "text_a": [
-        "61",
-        0
-      ],
-      "text_b": [
-        "40",
-        0
-      ]
-    },
-    "class_type": "VixTextConcatenate",
-    "_meta": {
-      "title": "Text Concatenate"
-    }
-  },
   "64": {
     "inputs": {
       "lora_name": "pencilbox.safetensors",
@@ -528,6 +512,23 @@
     "class_type": "LoraLoader",
     "_meta": {
       "title": "Load LoRA"
+    }
+  },
+  "68": {
+    "inputs": {
+      "string_a": [
+        "61",
+        0
+      ],
+      "string_b": [
+        "40",
+        0
+      ],
+      "delimiter": ", "
+    },
+    "class_type": "StringConcatenate",
+    "_meta": {
+      "title": "Concatenate"
     }
   }
 }

--- a/flows/photomaker_2.json
+++ b/flows/photomaker_2.json
@@ -348,7 +348,7 @@
         0
       ],
       "positive": [
-        "255",
+        "257",
         0
       ],
       "negative": [
@@ -480,7 +480,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/Photomaker_2/",
       "license": "",
       "tags": "[\"general\", \"portrait\"]",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -666,24 +666,6 @@
       "title": "🔧 Images Batch Multiple"
     }
   },
-  "255": {
-    "inputs": {
-      "delimiter": " ",
-      "clean_whitespace": "true",
-      "text_a": [
-        "226",
-        0
-      ],
-      "text_b": [
-        "256",
-        0
-      ]
-    },
-    "class_type": "VixTextConcatenate",
-    "_meta": {
-      "title": "Text Concatenate"
-    }
-  },
   "256": {
     "inputs": {
       "text": "img"
@@ -691,6 +673,23 @@
     "class_type": "VixMultilineText",
     "_meta": {
       "title": "Text Multiline"
+    }
+  },
+  "257": {
+    "inputs": {
+      "string_a": [
+        "226",
+        0
+      ],
+      "string_b": [
+        "256",
+        0
+      ],
+      "delimiter": " "
+    },
+    "class_type": "StringConcatenate",
+    "_meta": {
+      "title": "Concatenate"
     }
   }
 }

--- a/flows/sketch_pencil.json
+++ b/flows/sketch_pencil.json
@@ -2,7 +2,7 @@
   "6": {
     "inputs": {
       "text": [
-        "86",
+        "89",
         0
       ],
       "clip": [
@@ -167,7 +167,7 @@
       "documentation": "",
       "license": "",
       "tags": "[\"general\", \"sketch\"]",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -329,26 +329,38 @@
       "title": "Text Multiline"
     }
   },
-  "86": {
+  "88": {
     "inputs": {
-      "delimiter": ", ",
-      "clean_whitespace": "true",
-      "text_a": [
+      "string_a": [
         "69",
         0
       ],
-      "text_b": [
+      "string_b": [
         "81",
         0
       ],
-      "text_c": [
+      "delimiter": ", "
+    },
+    "class_type": "StringConcatenate",
+    "_meta": {
+      "title": "Concatenate"
+    }
+  },
+  "89": {
+    "inputs": {
+      "string_a": [
+        "88",
+        0
+      ],
+      "string_b": [
         "85",
         0
-      ]
+      ],
+      "delimiter": ", "
     },
-    "class_type": "VixTextConcatenate",
+    "class_type": "StringConcatenate",
     "_meta": {
-      "title": "Text Concatenate"
+      "title": "Concatenate"
     }
   }
 }


### PR DESCRIPTION
Two months ago such native node was added to Comfy: https://github.com/comfyanonymous/ComfyUI/pull/7952

Let's use it instead of our and mark our node as deprecated with the pending removal in Visionatrix `3.0` version.