### PR TITLE
chore: use StringReplace instead of VixTextReplace

### DIFF
--- a/flows/comicu_portrait.json
+++ b/flows/comicu_portrait.json
@@ -108,7 +108,7 @@
       ],
       "lora_clip_strength": 1,
       "positive": [
-        "415",
+        "416",
         0
       ],
       "negative": "nsfw, lowres, (bad), text, error, fewer, extra, missing, worst quality, jpeg artifacts, low quality, watermark, unfinished, displeasing, oldest, early, chromatic aberration, signature, extra digits, artistic error, username, scan, [abstract]",
@@ -207,7 +207,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/ComicuPortrait/",
       "license": "",
       "tags": "[\"anime\", \"portrait\"]",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -353,9 +353,26 @@
       "title": "Text Multiline"
     }
   },
-  "413": {
+  "416": {
     "inputs": {
-      "text": [
+      "string": [
+        "417",
+        0
+      ],
+      "find": "{prompt}",
+      "replace": [
+        "400",
+        0
+      ]
+    },
+    "class_type": "StringReplace",
+    "_meta": {
+      "title": "Replace"
+    }
+  },
+  "417": {
+    "inputs": {
+      "string": [
         "411",
         0
       ],
@@ -365,26 +382,9 @@
         0
       ]
     },
-    "class_type": "VixTextReplace",
+    "class_type": "StringReplace",
     "_meta": {
-      "title": "Text Replace"
-    }
-  },
-  "415": {
-    "inputs": {
-      "text": [
-        "413",
-        0
-      ],
-      "find": "{prompt}",
-      "replace": [
-        "400",
-        0
-      ]
-    },
-    "class_type": "VixTextReplace",
-    "_meta": {
-      "title": "Text Replace"
+      "title": "Replace"
     }
   }
 }

--- a/flows/photo_stickers.json
+++ b/flows/photo_stickers.json
@@ -174,7 +174,7 @@
   "88": {
     "inputs": {
       "text": [
-        "407",
+        "409",
         0
       ],
       "clip": [
@@ -190,7 +190,7 @@
   "91": {
     "inputs": {
       "text": [
-        "401",
+        "416",
         0
       ],
       "clip": [
@@ -249,7 +249,7 @@
   "284": {
     "inputs": {
       "text": [
-        "408",
+        "413",
         0
       ],
       "clip": [
@@ -265,7 +265,7 @@
   "287": {
     "inputs": {
       "text": [
-        "403",
+        "411",
         0
       ],
       "clip": [
@@ -324,7 +324,7 @@
   "298": {
     "inputs": {
       "text": [
-        "406",
+        "414",
         0
       ],
       "clip": [
@@ -340,7 +340,7 @@
   "301": {
     "inputs": {
       "text": [
-        "402",
+        "412",
         0
       ],
       "clip": [
@@ -399,7 +399,7 @@
   "326": {
     "inputs": {
       "text": [
-        "405",
+        "415",
         0
       ],
       "clip": [
@@ -415,7 +415,7 @@
   "329": {
     "inputs": {
       "text": [
-        "404",
+        "410",
         0
       ],
       "clip": [
@@ -855,7 +855,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/PhotoStickers/",
       "license": "",
       "tags": "[\"cartoon\", \"portrait\"]",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -1034,111 +1034,9 @@
       "title": "Text Multiline"
     }
   },
-  "401": {
+  "409": {
     "inputs": {
-      "text": [
-        "386",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "VixTextReplace",
-    "_meta": {
-      "title": "Text Replace"
-    }
-  },
-  "402": {
-    "inputs": {
-      "text": [
-        "393",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "VixTextReplace",
-    "_meta": {
-      "title": "Text Replace"
-    }
-  },
-  "403": {
-    "inputs": {
-      "text": [
-        "395",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "VixTextReplace",
-    "_meta": {
-      "title": "Text Replace"
-    }
-  },
-  "404": {
-    "inputs": {
-      "text": [
-        "397",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "VixTextReplace",
-    "_meta": {
-      "title": "Text Replace"
-    }
-  },
-  "405": {
-    "inputs": {
-      "text": [
-        "387",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "VixTextReplace",
-    "_meta": {
-      "title": "Text Replace"
-    }
-  },
-  "406": {
-    "inputs": {
-      "text": [
-        "390",
-        0
-      ],
-      "find": "{gender}",
-      "replace": [
-        "360",
-        0
-      ]
-    },
-    "class_type": "VixTextReplace",
-    "_meta": {
-      "title": "Text Replace"
-    }
-  },
-  "407": {
-    "inputs": {
-      "text": [
+      "string": [
         "399",
         0
       ],
@@ -1148,14 +1046,65 @@
         0
       ]
     },
-    "class_type": "VixTextReplace",
+    "class_type": "StringReplace",
     "_meta": {
-      "title": "Text Replace"
+      "title": "Replace"
     }
   },
-  "408": {
+  "410": {
     "inputs": {
-      "text": [
+      "string": [
+        "397",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "StringReplace",
+    "_meta": {
+      "title": "Replace"
+    }
+  },
+  "411": {
+    "inputs": {
+      "string": [
+        "395",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "StringReplace",
+    "_meta": {
+      "title": "Replace"
+    }
+  },
+  "412": {
+    "inputs": {
+      "string": [
+        "393",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "StringReplace",
+    "_meta": {
+      "title": "Replace"
+    }
+  },
+  "413": {
+    "inputs": {
+      "string": [
         "391",
         0
       ],
@@ -1165,9 +1114,60 @@
         0
       ]
     },
-    "class_type": "VixTextReplace",
+    "class_type": "StringReplace",
     "_meta": {
-      "title": "Text Replace"
+      "title": "Replace"
+    }
+  },
+  "414": {
+    "inputs": {
+      "string": [
+        "390",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "StringReplace",
+    "_meta": {
+      "title": "Replace"
+    }
+  },
+  "415": {
+    "inputs": {
+      "string": [
+        "387",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "StringReplace",
+    "_meta": {
+      "title": "Replace"
+    }
+  },
+  "416": {
+    "inputs": {
+      "string": [
+        "386",
+        0
+      ],
+      "find": "{gender}",
+      "replace": [
+        "360",
+        0
+      ]
+    },
+    "class_type": "StringReplace",
+    "_meta": {
+      "title": "Replace"
     }
   }
 }

--- a/flows/photomaker_1.json
+++ b/flows/photomaker_1.json
@@ -22,7 +22,7 @@
   "6": {
     "inputs": {
       "text": [
-        "134",
+        "144",
         0
       ],
       "clip": [
@@ -38,7 +38,7 @@
   "7": {
     "inputs": {
       "text": [
-        "138",
+        "147",
         0
       ],
       "clip": [
@@ -186,7 +186,7 @@
   "73": {
     "inputs": {
       "text": [
-        "137",
+        "145",
         0
       ],
       "photomaker": [
@@ -288,7 +288,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/Photomaker_1/",
       "license": "",
       "tags": "[\"general\", \"portrait\", \"cartoon\"]",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -396,71 +396,6 @@
       "title": "Auto Crop Faces"
     }
   },
-  "134": {
-    "inputs": {
-      "text": [
-        "135",
-        0
-      ],
-      "find": "{prompt}",
-      "replace": [
-        "122",
-        0
-      ]
-    },
-    "class_type": "VixTextReplace",
-    "_meta": {
-      "title": "Text Replace"
-    }
-  },
-  "135": {
-    "inputs": {
-      "text": [
-        "140",
-        0
-      ],
-      "find": ", photomaker",
-      "replace": ""
-    },
-    "class_type": "VixTextReplace",
-    "_meta": {
-      "title": "Text Replace"
-    }
-  },
-  "137": {
-    "inputs": {
-      "text": [
-        "140",
-        0
-      ],
-      "find": "{prompt}",
-      "replace": [
-        "122",
-        0
-      ]
-    },
-    "class_type": "VixTextReplace",
-    "_meta": {
-      "title": "Text Replace"
-    }
-  },
-  "138": {
-    "inputs": {
-      "text": [
-        "139",
-        0
-      ],
-      "find": "{negative_prompt}",
-      "replace": [
-        "123",
-        0
-      ]
-    },
-    "class_type": "VixTextReplace",
-    "_meta": {
-      "title": "Text Replace"
-    }
-  },
   "139": {
     "inputs": {
       "key": [
@@ -545,6 +480,71 @@
     "class_type": "VixDictionaryNew",
     "_meta": {
       "title": "Dictionary New"
+    }
+  },
+  "144": {
+    "inputs": {
+      "string": [
+        "146",
+        0
+      ],
+      "find": "{prompt}",
+      "replace": [
+        "122",
+        0
+      ]
+    },
+    "class_type": "StringReplace",
+    "_meta": {
+      "title": "Replace"
+    }
+  },
+  "145": {
+    "inputs": {
+      "string": [
+        "140",
+        0
+      ],
+      "find": "{prompt}",
+      "replace": [
+        "122",
+        0
+      ]
+    },
+    "class_type": "StringReplace",
+    "_meta": {
+      "title": "Replace"
+    }
+  },
+  "146": {
+    "inputs": {
+      "string": [
+        "140",
+        0
+      ],
+      "find": ", photomaker",
+      "replace": ""
+    },
+    "class_type": "StringReplace",
+    "_meta": {
+      "title": "Replace"
+    }
+  },
+  "147": {
+    "inputs": {
+      "string": [
+        "139",
+        0
+      ],
+      "find": "{negative_prompt}",
+      "replace": [
+        "123",
+        0
+      ]
+    },
+    "class_type": "StringReplace",
+    "_meta": {
+      "title": "Replace"
     }
   }
 }

--- a/flows/sketch_portrait.json
+++ b/flows/sketch_portrait.json
@@ -11,7 +11,7 @@
   "290": {
     "inputs": {
       "text": [
-        "406",
+        "408",
         0
       ],
       "clip": [
@@ -39,7 +39,7 @@
   },
   "336": {
     "inputs": {
-      "weight": 0.7000000000000001,
+      "weight": 0.7,
       "start_at": 0,
       "end_at": 0.85,
       "instantid": [
@@ -238,7 +238,7 @@
       "documentation": "https://visionatrix.github.io/VixFlowsDocs/Flows/SketchPortrait/",
       "license": "",
       "tags": "[\"anime\", \"sketch\", \"portrait\"]",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "requires": "[]",
       "is_seed_supported": true,
       "is_count_supported": true,
@@ -348,10 +348,10 @@
       "title": "Text Multiline"
     }
   },
-  "406": {
+  "408": {
     "inputs": {
-      "text": [
-        "407",
+      "string": [
+        "411",
         0
       ],
       "find": "{prompt}",
@@ -360,14 +360,14 @@
         0
       ]
     },
-    "class_type": "VixTextReplace",
+    "class_type": "StringReplace",
     "_meta": {
-      "title": "Text Replace"
+      "title": "Replace"
     }
   },
-  "407": {
+  "411": {
     "inputs": {
-      "text": [
+      "string": [
         "405",
         0
       ],
@@ -377,9 +377,9 @@
         0
       ]
     },
-    "class_type": "VixTextReplace",
+    "class_type": "StringReplace",
     "_meta": {
-      "title": "Text Replace"
+      "title": "Replace"
     }
   }
 }


### PR DESCRIPTION
The same as in the #117 PR but for TextReplace nodes.

